### PR TITLE
[1.1.0] Fix KeyError and add platform-aware downloads

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: crystal-lang/install-crystal@v1
         with:
-          crystal: latest
+          crystal: 1.17.1
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: crystal-lang/install-crystal@v1
         with:
-          crystal: latest
+          crystal: 1.17.1
       - name: Install OpenSSL 3
         run: brew install openssl@3
       - name: Install shards
@@ -192,7 +192,7 @@ jobs:
 
       - uses: crystal-lang/install-crystal@v1
         with:
-          crystal: latest
+          crystal: 1.17.1
 
       # Ensure MSVC build environment is set up (cl, link, mt, etc.)
       - name: Set up MSVC Developer Command Prompt

--- a/jb_updater/shard.lock
+++ b/jb_updater/shard.lock
@@ -6,5 +6,5 @@ shards:
 
   uing:
     git: https://github.com/kojix2/uing.git
-    version: 0.1.1
+    version: 0.1.2
 

--- a/jb_updater/spec/utils_spec.cr
+++ b/jb_updater/spec/utils_spec.cr
@@ -27,4 +27,27 @@ describe Utils do
       Utils.build_in_range?("2023.1.0", "2024.0.0", "2024.3.0").should be_false
     end
   end
+
+  describe ".product_code" do
+    it "maps known product names" do
+      Utils.product_code("RubyMine2025.2").should eq "RM"
+      Utils.product_code("WebStorm2025.1").should eq "WS"
+      Utils.product_code("PyCharm2024.3").should eq "PY"
+      Utils.product_code("CLion2025.1").should eq "CL"
+      Utils.product_code("GoLand2025.2").should eq "GO"
+      Utils.product_code("IntelliJ IDEA 2025.2").should eq "IU"
+      Utils.product_code("PhpStorm2025.1").should eq "PS"
+      Utils.product_code("Rider2025.1").should eq "RD"
+    end
+
+    it "matches lowercase names (e.g. from --ide-path)" do
+      Utils.product_code("phpstorm").should eq "PS"
+      Utils.product_code("webstorm").should eq "WS"
+      Utils.product_code("intellij").should eq "IU"
+    end
+
+    it "falls back to first two uppercase characters for unknown names" do
+      Utils.product_code("MyCustomIDE").should eq "MY"
+    end
+  end
 end

--- a/jb_updater/src/jb_updater/detect_products.cr
+++ b/jb_updater/src/jb_updater/detect_products.cr
@@ -153,19 +153,7 @@ module JBUpdater
     # @param name [String] Product name (e.g. "RubyMine2025.2")
     # @return [String] Product code (e.g. "RM")
     def infer_code(name : String) : String
-      mapping = {
-        "RubyMine" => "RM",
-        "WebStorm" => "WS",
-        "PyCharm"  => "PY",
-        "CLion"    => "CL",
-        "GoLand"   => "GO",
-        "IntelliJ" => "IU",
-        "PhpStorm" => "PS",
-        "Rider"    => "RD",
-      }
-
-      key = name.gsub(/[\d ].*/, "")
-      mapping[key]? || name[0, 2].upcase
+      Utils.product_code(name)
     end
 
     # Converts a product name and code into an API build string.

--- a/jb_updater/src/jb_updater/ide_updater.cr
+++ b/jb_updater/src/jb_updater/ide_updater.cr
@@ -68,19 +68,51 @@ module JBUpdater
       data = JSON.parse(body)
       version = data[product_code][0]["version"].as_s
       downloads = data[product_code][0]["downloads"]
-      link = nil
 
-      arch = opts.arch || autodetect_arch
+      platform_key = download_key_for(platform, opts.arch)
 
-      if arch == "arm" && downloads["macM1"]?
-        link = downloads["macM1"]["link"].as_s
-      else
-        link = downloads["mac"]["link"].as_s
-      end
+      entry = downloads[platform_key]? || raise "No download entry found for platform '#{platform}' (#{platform_key}) for #{product_code}"
+      link = entry["link"].as_s
 
       dmg_url = link
       Log.success("Latest version #{version}")
       URI.parse(dmg_url)
+    end
+
+    # Determines the current OS platform.
+    #
+    # @return [String] `"mac"`, `"linux"`, or `"windows"`
+    private def platform : String
+      {% if flag?(:darwin) %}
+        "mac"
+      {% elsif flag?(:linux) %}
+        "linux"
+      {% elsif flag?(:win32) %}
+        "windows"
+      {% else %}
+        raise "Unsupported OS"
+      {% end %}
+    end
+
+    # Maps platform + architecture to the JetBrains releases API download key.
+    #
+    # - **mac** (Apple Silicon): `macM1`; otherwise: `mac`
+    # - **linux** (ARM64): `linuxARM64`; otherwise: `linux`
+    # - **windows**: `windows`
+    #
+    # @param platform [String] OS platform (`"mac"`, `"linux"`, `"windows"`)
+    # @param arch [String?] Architecture (`"arm"` or `"intel"`); autodetected if nil
+    # @return [String] Download key in the JetBrains releases API payload
+    private def download_key_for(platform : String, arch : String?) : String
+      cpu = arch || autodetect_arch
+      case platform
+      when "mac"
+        cpu == "arm" ? "macM1" : "mac"
+      when "linux"
+        cpu == "arm" ? "linuxARM64" : "linux"
+      else
+        "windows"
+      end
     end
 
     # Detects the CPU architecture by running `uname -m`.
@@ -104,16 +136,12 @@ module JBUpdater
 
     # Maps a product name to its JetBrains product code.
     #
-    # @param product [String] Product name (e.g. `"RubyMine2025.2"`)
-    # @return [String] Product code (e.g. `"RM"`)
+    # Delegates to {JBUpdater.Utils.product_code} (case-insensitive).
+    #
+    # @param product [String] Product name (e.g. `"PhpStorm2025.1"` or `"phpstorm"`)
+    # @return [String] Product code (e.g. `"PS"`)
     private def infer_product_code(product : String) : String
-      {
-        "RubyMine" => "RM",
-        "WebStorm" => "WS",
-        "PyCharm"  => "PY",
-        "CLion"    => "CL",
-        "GoLand"   => "GO",
-      }[product.gsub(/\d+.*/, "")] || product[0, 2].upcase
+      Utils.product_code(product)
     end
 
     # ------------------------------------------------------------------------
@@ -126,7 +154,12 @@ module JBUpdater
     # @param product [String] Product name (for logging)
     # @param uri [URI] Download URL (with CDN override already applied)
     private def upgrade_direct(product : String, uri : URI) : Nil
-      dmg_path = File.join(Dir.tempdir, "upgrade-#{product}-#{Time.utc.to_unix}.dmg")
+      ext = case platform
+            when "mac"     then ".dmg"
+            when "windows" then ".exe"
+            else                ".tar.gz"
+            end
+      dmg_path = File.join(Dir.tempdir, "upgrade-#{product}-#{Time.utc.to_unix}#{ext}")
 
       cdn_uri = uri
 

--- a/jb_updater/src/jb_updater/utils.cr
+++ b/jb_updater/src/jb_updater/utils.cr
@@ -119,6 +119,31 @@ module JBUpdater
       (s <= b) && (b <= u)
     end
 
+    # Maps a product name to its JetBrains product code.
+    #
+    # Strips trailing version numbers and spaces, matches the base
+    # name case-insensitively, and returns the short code
+    # (e.g. `"RubyMine2025.2"` -> `"RM"`, `"phpstorm"` -> `"PS"`).
+    # Unknown names fall back to the first two uppercase characters.
+    #
+    # @param name [String] Product name (e.g. `"RubyMine2025.2"` or `"phpstorm"`)
+    # @return [String] Product code (e.g. `"RM"`)
+    def self.product_code(name : String) : String
+      mapping = {
+        "rubymine" => "RM",
+        "webstorm" => "WS",
+        "pycharm"  => "PY",
+        "clion"    => "CL",
+        "goland"   => "GO",
+        "intellij" => "IU",
+        "phpstorm" => "PS",
+        "rider"    => "RD",
+      }
+
+      key = name.gsub(/[\d ].*/, "").downcase
+      mapping[key]? || name[0, 2].upcase
+    end
+
     # URL-encodes a path segment, replacing `%20` with `+`.
     #
     # @param str [String] Raw path segment

--- a/jb_updater/src/main.cr
+++ b/jb_updater/src/main.cr
@@ -21,6 +21,7 @@ if opts.list_ide_releases?
   end
 
   product_code = opts.product || raise "missing --product"
+  product_code = JBUpdater::Utils.product_code(product_code)
 
   releases = JBUpdater::IDEReleases.fetch(
     product_code,


### PR DESCRIPTION
## Summary

Fixes `KeyError: Missing hash key` when using `--upgrade-ide` with JetBrains products not present in a hardcoded map (e.g. PhpStorm), and makes IDE downloads platform-aware (macOS / Linux / Windows instead of always `.dmg`).

Fixes #21.

## Changes

- **`Utils.product_code`** — single case-insensitive `{product=>code}` mapping (`PhpStorm`->`PS`, `IntelliJ`->`IU`, `Rider` ->`RD`, etc.) with safe fallback. `DetectProducts.infer_code` and `IDEUpdater` now share it instead of two divergent maps.
- **`ide_updater.cr`** — `--upgrade-ide`:
  - no more `Hash#[]` KeyError crash on unknown/lowercase product names (`phpstorm` via `--ide-path` now resolves correctly);
  - download key chosen by OS + arch: `mac`/`macM1`, `linux`/`linuxARM64`, `windows` (previously always `.dmg`);
  - saved file extension follows the platform.
- **`main.cr`** — `--list-ide-releases` normalizes the product code too (`phpstorm` works).
- **CI** — pin Crystal to `1.17.1` (matching `.tool-versions`); `ameba 1.6.4` doesn't build under Crystal 1.21 (`preview_mt` removed, `Lexer#next_string_array_token` gone).
- **`shard.lock`** — `uing` 0.1.1 -> 0.1.2.
- **Specs** — `Utils.product_code` coverage (mapping, lowercase, fallback).

## Verification

- [ ] `crystal spec` — 94 examples, 0 failures
- [ ] `bin/ameba` — 26 files inspected, 0 failures
- [ ] Manual: `--product PhpStorm --upgrade-ide` fetches `PS` (no KeyError)
- [ ] Manual: `--ide-path /Applications/phpstorm --upgrade-ide` -> `PHPS`... -> `PS`