### PR TITLE
[1.1.0] Fixed bugs after manual QA

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -40,7 +40,7 @@ jobs:
         working-directory: jb_updater
         run: |
           crystal build src/main.cr --release --no-debug -o jb_updater
-          crystal build src/gui/main_gui.cr --release --no-debug -o jb_updater_gui
+          crystal build src/gui/main_gui.cr --release -Dpreview_mt --no-debug -o jb_updater_gui
       - name: Smoke test — CLI binary loads
         working-directory: jb_updater
         run: ./jb_updater --help
@@ -104,7 +104,7 @@ jobs:
           crystal build src/main.cr --release --no-debug \
             --link-flags "-L${brew_prefix}/lib -I${brew_prefix}/include" \
             -o jb_updater
-          crystal build src/gui/main_gui.cr --release --no-debug \
+          crystal build src/gui/main_gui.cr --release -Dpreview_mt --no-debug \
             --link-flags "-L${brew_prefix}/lib -I${brew_prefix}/include" \
             -o jb_updater_gui
 
@@ -214,7 +214,7 @@ jobs:
         working-directory: jb_updater
         run: |
           crystal build src/main.cr --release --no-debug -o jb_updater.exe
-          crystal build src/gui/main_gui.cr --release --no-debug --link-flags=/SUBSYSTEM:WINDOWS -o jb_updater_gui.exe
+          crystal build src/gui/main_gui.cr --release -Dpreview_mt --no-debug --link-flags=/SUBSYSTEM:WINDOWS -o jb_updater_gui.exe
 
       - name: Bundle Crystal runtime DLLs
         shell: pwsh

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Build GUI
         working-directory: ./jb_updater
-        run: crystal build src/gui/main_gui.cr --release -o jb_updater_gui
+        run: crystal build src/gui/main_gui.cr --release -Dpreview_mt -o jb_updater_gui
 
       - name: Run CLI --help
         working-directory: ./jb_updater

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ jb_updater/jb_updater_cli
 jb_updater/bin/ameba
 jb_updater/bin/jb_updater
 jb_updater/bin/jb_updater_gui
+jb_updater/qa_artifacts
+

--- a/jb_updater/README.md
+++ b/jb_updater/README.md
@@ -178,8 +178,7 @@ On macOS:
 
 On Linux/Windows:
 
-- Use the `*-bundle-*` archives so GUI and CLI are in the same directory.
-- Run the GUI binary (`./jb_updater_gui` or `jb_updater_gui.exe`).
+- Run the GUI binary (`./jb_updater_gui` or `jb_updater_gui.exe`) from the `*-bundle-*` archives.
 
 ---
 
@@ -257,11 +256,15 @@ GitHub Actions will attach fresh binaries for that tag to the Release page.
 
 ### GUI background threads
 
-The GUI runs marketplace fetches, plugin search, and installs on background threads and marshals UI updates back to the
-main thread with `UIng.queue_main`. On Crystal >= 1.21 the single-threaded runtime does not install a fiber execution
-context on `Thread.new` threads, so background threads that touch the evented I/O fail with
+The GUI runs marketplace fetches, plugin search, downloads, and IDE-release queries on background threads and marshals
+UI updates back to the main thread with `UIng.queue_main`. On Crystal >= 1.21 the single-threaded runtime does not
+install a fiber execution context on `Thread.new` threads, so background threads that touch evented I/O fail with
 `Thread#execution_context cannot be nil`. Building the GUI with `-Dpreview_mt` sets up per-thread contexts and makes
 these threads safe.
+
+GUI button actions run the same logic in-process (no `jb_updater` subprocess), mirroring the CLI argument dispatch.
+This avoids `Process.run` from a background thread, which deadlocks under Crystal 1.21 (child process spawning is only
+supported on the main execution context).
 
 - Close your JetBrains IDE before updating plugins (to avoid locked files).
 - Requires the system `unzip` tool for extracting plugin archives.

--- a/jb_updater/README.md
+++ b/jb_updater/README.md
@@ -194,8 +194,9 @@ shards install
 crystal build src/main.cr --release -o jb_updater
 ./jb_updater --help
 
-# GUI
-crystal build src/gui/main_gui.cr --release -o jb_updater_gui
+# GUI (requires -Dpreview_mt so background threads can do network I/O,
+# see "GUI background threads" note below)
+crystal build src/gui/main_gui.cr --release -Dpreview_mt -o jb_updater_gui
 ./jb_updater_gui
 ```
 
@@ -219,7 +220,7 @@ Build optimized binaries:
 
 ```bash
 crystal build src/main.cr --release -o jb_updater
-crystal build src/gui/main_gui.cr --release -o jb_updater_gui
+crystal build src/gui/main_gui.cr --release -Dpreview_mt -o jb_updater_gui
 ```
 
 ---
@@ -253,6 +254,14 @@ GitHub Actions will attach fresh binaries for that tag to the Release page.
 ---
 
 ## Notes
+
+### GUI background threads
+
+The GUI runs marketplace fetches, plugin search, and installs on background threads and marshals UI updates back to the
+main thread with `UIng.queue_main`. On Crystal >= 1.21 the single-threaded runtime does not install a fiber execution
+context on `Thread.new` threads, so background threads that touch the evented I/O fail with
+`Thread#execution_context cannot be nil`. Building the GUI with `-Dpreview_mt` sets up per-thread contexts and makes
+these threads safe.
 
 - Close your JetBrains IDE before updating plugins (to avoid locked files).
 - Requires the system `unzip` tool for extracting plugin archives.

--- a/jb_updater/spec/gui_actions_spec.cr
+++ b/jb_updater/spec/gui_actions_spec.cr
@@ -10,9 +10,9 @@ module JBUpdater
           Actions.resolve_build("RM-252", "", detected).should eq "RM-252"
         end
 
-        it "returns ide_product_text over build_text" do
+        it "returns build_text over ide_product_text" do
           detected = [DetectedProduct.new("Test", "TT", "TT-999", nil, nil, nil)]
-          Actions.resolve_build("RM-252", "WS-242", detected).should eq "RM-252"
+          Actions.resolve_build("RM-252", "WS-242", detected).should eq "WS-242"
         end
 
         it "falls back to build_text when ide_product_text is nil" do

--- a/jb_updater/spec/ide_releases_spec.cr
+++ b/jb_updater/spec/ide_releases_spec.cr
@@ -1,0 +1,35 @@
+require "./spec_helper"
+include JBUpdater
+
+describe IDEReleases do
+  describe "#extract_releases_arr" do
+    it "returns the exact-code array when present" do
+      data = JSON.parse(%({"RM":[{"version":"2026.2.1"}]}))
+      if arr = IDEReleases.extract_releases_arr(data, "RM")
+        arr.size.should eq 1
+      else
+        fail "expected releases array"
+      end
+    end
+
+    it "falls back to the variant key when the exact code is absent" do
+      # JetBrains returns "IIU" for code "IU" — the code key must not win.
+      data = JSON.parse(%({"IIU":[{"version":"2026.2.1"},{"version":"2026.2"}]}))
+      if arr = IDEReleases.extract_releases_arr(data, "IU")
+        arr.size.should eq 2
+      else
+        fail "expected releases array"
+      end
+    end
+
+    it "returns nil when the response has no array values" do
+      data = JSON.parse(%({"error":"boom"}))
+      IDEReleases.extract_releases_arr(data, "RM").should be_nil
+    end
+
+    it "returns nil for an empty response object" do
+      data = JSON.parse(%({}))
+      IDEReleases.extract_releases_arr(data, "RM").should be_nil
+    end
+  end
+end

--- a/jb_updater/spec/plugin_marketplace_spec.cr
+++ b/jb_updater/spec/plugin_marketplace_spec.cr
@@ -95,6 +95,28 @@ describe PluginInfo do
         XML
       PluginInfo.parse(xml).size.should eq 1
     end
+
+    it "parses a rating" do
+      xml = <<-XML
+        <plugin-list>
+          <idea-plugin>
+            <id>com.example.rated</id>
+            <name>Rated Plugin</name>
+            <description>Big</description>
+            <rating>4.6</rating>
+          </idea-plugin>
+          <idea-plugin>
+            <id>com.example.unrated</id>
+            <name>Unrated Plugin</name>
+            <description>Big</description>
+          </idea-plugin>
+        </plugin-list>
+        XML
+      plugins = PluginInfo.parse(xml)
+      plugins.size.should eq 2
+      plugins[0].rating.should eq 4.6
+      plugins[1].rating.should eq 0.0
+    end
   end
 
   describe "#download_url" do
@@ -138,9 +160,19 @@ describe PluginInfo do
   end
 
   describe "#star_rating" do
-    it "returns five stars" do
+    it "renders em-dash for unrated plugins" do
       p = PluginInfo.new(id: 1_i64, xml_id: "x", name: "x", description: "")
-      p.star_rating.should eq "⭐⭐⭐⭐⭐"
+      p.star_rating.should eq "—"
+    end
+
+    it "renders filled stars for rated plugins" do
+      p = PluginInfo.new(id: 1_i64, xml_id: "x", name: "x", description: "", rating: 4.2)
+      p.star_rating.should eq "★★★★☆"
+    end
+
+    it "renders five stars for a perfect rating" do
+      p = PluginInfo.new(id: 1_i64, xml_id: "x", name: "x", description: "", rating: 5.0)
+      p.star_rating.should eq "★★★★★"
     end
   end
 end

--- a/jb_updater/spec/plugin_marketplace_spec.cr
+++ b/jb_updater/spec/plugin_marketplace_spec.cr
@@ -175,4 +175,18 @@ describe PluginInfo do
       p.star_rating.should eq "★★★★★"
     end
   end
+
+  describe "#with_compat_note" do
+    it "returns a copy with the note attached and all fields preserved" do
+      base = PluginInfo.new(id: 32349_i64, xml_id: "com.florexlabs.docscribe", name: "DocScribe",
+        description: "desc", downloads: 46_i64, rating: 4.5)
+      noted = base.with_compat_note("Declared for build RM-261, not for RM-262 — may still work")
+      noted.compat_note.should eq "Declared for build RM-261, not for RM-262 — may still work"
+      noted.name.should eq "DocScribe"
+      noted.xml_id.should eq "com.florexlabs.docscribe"
+      noted.downloads.should eq 46_i64
+      noted.rating.should eq 4.5
+      base.compat_note.should be_nil
+    end
+  end
 end

--- a/jb_updater/spec/plugin_meta_spec.cr
+++ b/jb_updater/spec/plugin_meta_spec.cr
@@ -1,4 +1,5 @@
 require "./spec_helper"
+require "compress/zip"
 include JBUpdater
 
 describe PluginMeta do
@@ -116,6 +117,21 @@ describe PluginMeta do
   describe ".read_text_from_jar" do
     it "returns nil when jar does not exist" do
       PluginMeta.read_text_from_jar("/tmp/nonexistent.jar", "META-INF/plugin.xml").should be_nil
+    end
+
+    it "reads plugin.xml out of a real zip/jar archive" do
+      with_tmpdir do |dir|
+        jar = File.join(dir, "plugin.jar")
+        File.open(jar, "w") do |io|
+          Compress::Zip::Writer.open(io) do |zip|
+            zip.add("META-INF/plugin.xml") { |e| e.print "<idea-plugin><id>com.example.jartest</id></idea-plugin>" }
+          end
+        end
+
+        xml = PluginMeta.read_text_from_jar(jar, "META-INF/plugin.xml")
+        xml.should_not be_nil
+        xml.try(&.should contain "com.example.jartest")
+      end
     end
   end
 end

--- a/jb_updater/spec/resolve_product_folder_spec.cr
+++ b/jb_updater/spec/resolve_product_folder_spec.cr
@@ -57,6 +57,61 @@ describe Utils do
       end
     end
 
+    it "ignores backup folders when resolving the latest version" do
+      tmp = File.join(Dir.tempdir, "jb-test-#{Random::Secure.hex(4)}")
+      base = ""
+
+      {% if flag?(:darwin) %}
+        base = File.join(tmp, "Library/Application Support/JetBrains")
+        ENV["HOME"] = tmp
+      {% elsif flag?(:linux) %}
+        base = File.join(tmp, ".local/share/JetBrains")
+        ENV["HOME"] = tmp
+      {% elsif flag?(:win32) %}
+        base = File.join(tmp, "AppData", "Roaming", "JetBrains")
+        FileUtils.mkdir_p(File.dirname(base))
+        ENV["APPDATA"] = File.join(tmp, "AppData", "Roaming")
+      {% end %}
+
+      FileUtils.mkdir_p(File.join(base, "WebStorm2025.2"))
+      FileUtils.mkdir_p(File.join(base, "WebStorm2025.2-backup"))
+      FileUtils.mkdir_p(File.join(base, "WebStorm2024.1.bak.1700000000"))
+
+      begin
+        latest = Utils.resolve_product_folder("WebStorm")
+        latest.should eq "WebStorm2025.2"
+      ensure
+        FileUtils.rm_rf(tmp)
+      end
+    end
+
+    it "raises when only a backup-style folder matches" do
+      tmp = File.join(Dir.tempdir, "jb-test-#{Random::Secure.hex(4)}")
+      base = ""
+
+      {% if flag?(:darwin) %}
+        base = File.join(tmp, "Library/Application Support/JetBrains")
+        ENV["HOME"] = tmp
+      {% elsif flag?(:linux) %}
+        base = File.join(tmp, ".local/share/JetBrains")
+        ENV["HOME"] = tmp
+      {% elsif flag?(:win32) %}
+        base = File.join(tmp, "AppData", "Roaming", "JetBrains")
+        FileUtils.mkdir_p(File.dirname(base))
+        ENV["APPDATA"] = File.join(tmp, "AppData", "Roaming")
+      {% end %}
+
+      FileUtils.mkdir_p(File.join(base, "FooIDE2025.2-backup"))
+
+      begin
+        expect_raises(Exception, /No config folder/) do
+          Utils.resolve_product_folder("FooIDE")
+        end
+      ensure
+        FileUtils.rm_rf(tmp)
+      end
+    end
+
     it "raises if no matching folder found" do
       tmp = File.join(Dir.tempdir, "jb-test-#{Random::Secure.hex(4)}")
       base = ""

--- a/jb_updater/spec/utils_spec.cr
+++ b/jb_updater/spec/utils_spec.cr
@@ -46,8 +46,48 @@ describe Utils do
       Utils.product_code("intellij").should eq "IU"
     end
 
+    it "maps short and alternate names" do
+      Utils.product_code("ruby").should eq "RM"
+      Utils.product_code("idea").should eq "IU"
+      Utils.product_code("rm").should eq "RM"
+      Utils.product_code("ws").should eq "WS"
+      Utils.product_code("py").should eq "PY"
+    end
+
     it "falls back to first two uppercase characters for unknown names" do
       Utils.product_code("MyCustomIDE").should eq "MY"
+    end
+  end
+
+  describe ".version_numbers" do
+    it "parses plain version suffix" do
+      Utils.version_numbers("2025.2").should eq [2025.0, 2.0, 0.0]
+    end
+
+    it "does not raise on backup suffix" do
+      Utils.version_numbers("2025.2-backup").should eq [2025.0, 2.0, 0.0]
+    end
+
+    it "does not raise on alpha fragment" do
+      Utils.version_numbers("2025.2-eap").should eq [2025.0, 2.0, 0.0]
+    end
+
+    it "parses full three-part version" do
+      Utils.version_numbers("2025.2.1").should eq [2025.0, 2.0, 1.0]
+    end
+  end
+
+  describe ".backup_folder?" do
+    it "detects .bak timestamps" do
+      Utils.backup_folder?("WebStorm2025.2.bak.1700000000").should be_true
+    end
+
+    it "detects -backup suffix" do
+      Utils.backup_folder?("WebStorm2025.2-backup").should be_true
+    end
+
+    it "accepts regular folders" do
+      Utils.backup_folder?("WebStorm2025.2").should be_false
     end
   end
 end

--- a/jb_updater/spec/utils_spec.cr
+++ b/jb_updater/spec/utils_spec.cr
@@ -78,6 +78,29 @@ describe Utils do
     end
   end
 
+  describe ".previous_builds" do
+    it "generates next older minor build for the same product" do
+      Utils.previous_builds("RM-262").should eq ["RM-261", "RM-253", "RM-252", "RM-251", "RM-243", "RM-242", "RM-241", "RM-233"]
+    end
+
+    it "handles full build string with patch number" do
+      Utils.previous_builds("RM-262.9437.192", limit: 3).should eq ["RM-261", "RM-253", "RM-252"]
+    end
+
+    it "respects the limit" do
+      Utils.previous_builds("RM-262", limit: 2).should eq ["RM-261", "RM-253"]
+    end
+
+    it "returns empty for minor 0" do
+      Utils.previous_builds("RM-260").should be_empty
+    end
+
+    it "returns empty for malformed input" do
+      Utils.previous_builds("not-a-build").should be_empty
+      Utils.previous_builds("").should be_empty
+    end
+  end
+
   describe ".latest_versioned_config_dir" do
     it "returns nil when base dir does not exist" do
       Utils.latest_versioned_config_dir("/tmp/__jb_no_such_dir__", "RubyMine").should be_nil

--- a/jb_updater/spec/utils_spec.cr
+++ b/jb_updater/spec/utils_spec.cr
@@ -189,7 +189,7 @@ describe Utils do
         zip_path = File.join(dir, "archive.zip")
         File.open(zip_path, "w") do |io|
           Compress::Zip::Writer.open(io) do |zip|
-            zip.add("plugin/file.txt") { |e| e.print "x" }
+            zip.add("plugin/file.txt", &.print("x"))
           end
         end
 
@@ -208,7 +208,7 @@ describe Utils do
         zip_path = File.join(dir, "archive.zip")
         File.open(zip_path, "w") do |io|
           Compress::Zip::Writer.open(io) do |zip|
-            zip.add("plugin1/lib/a.jar") { |e| e.print "jar-bytes" }
+            zip.add("plugin1/lib/a.jar", &.print("jar-bytes"))
           end
         end
 

--- a/jb_updater/spec/utils_spec.cr
+++ b/jb_updater/spec/utils_spec.cr
@@ -78,6 +78,82 @@ describe Utils do
     end
   end
 
+  describe ".latest_versioned_config_dir" do
+    it "returns nil when base dir does not exist" do
+      Utils.latest_versioned_config_dir("/tmp/__jb_no_such_dir__", "RubyMine").should be_nil
+    end
+
+    it "returns nil when base dir is empty" do
+      Dir.mkdir_p("/tmp/__jb_empty_base__")
+      begin
+        Utils.latest_versioned_config_dir("/tmp/__jb_empty_base__", "RubyMine").should be_nil
+      ensure
+        FileUtils.rm_rf("/tmp/__jb_empty_base__")
+      end
+    end
+
+    it "returns the newest versioned dir, not an arbitrary glob match" do
+      base = "/tmp/__jb_multi__"
+      FileUtils.mkdir_p(File.join(base, "RubyMine2025.3"))
+      FileUtils.mkdir_p(File.join(base, "RubyMine2026.1"))
+      FileUtils.mkdir_p(File.join(base, "RubyMine2026.2"))
+      begin
+        result = Utils.latest_versioned_config_dir(base, "RubyMine")
+        result.should eq File.join(base, "RubyMine2026.2")
+      ensure
+        FileUtils.rm_rf(base)
+      end
+    end
+
+    it "skips backup folders and names of other products" do
+      base = "/tmp/__jb_mixed__"
+      FileUtils.mkdir_p(File.join(base, "RubyMine2026.2-backup"))
+      FileUtils.mkdir_p(File.join(base, "PhpStorm2026.2"))
+      FileUtils.mkdir_p(File.join(base, "RubyMine2026.1"))
+      begin
+        result = Utils.latest_versioned_config_dir(base, "RubyMine")
+        result.should eq File.join(base, "RubyMine2026.1")
+      ensure
+        FileUtils.rm_rf(base)
+      end
+    end
+
+    it "handles full product folder names with trailing version" do
+      base = "/tmp/__jb_fullname__"
+      FileUtils.mkdir_p(File.join(base, "PyCharm2024.3"))
+      FileUtils.mkdir_p(File.join(base, "PyCharm2025.1"))
+      begin
+        result = Utils.latest_versioned_config_dir(base, "PyCharm")
+        result.should eq File.join(base, "PyCharm2025.1")
+      ensure
+        FileUtils.rm_rf(base)
+      end
+    end
+
+    it "matches an exact folder when the name already includes the version" do
+      base = "/tmp/__jb_exact__"
+      FileUtils.mkdir_p(File.join(base, "RubyMine2026.2"))
+      begin
+        result = Utils.latest_versioned_config_dir(base, "RubyMine2026.2")
+        result.should eq File.join(base, "RubyMine2026.2")
+      ensure
+        FileUtils.rm_rf(base)
+      end
+    end
+
+    it "never matches a longer-name product (RubyMineEAP)" do
+      base = "/tmp/__jb_prefix__"
+      FileUtils.mkdir_p(File.join(base, "RubyMineEAP"))
+      FileUtils.mkdir_p(File.join(base, "RubyMine2026.1"))
+      begin
+        result = Utils.latest_versioned_config_dir(base, "RubyMine")
+        result.should eq File.join(base, "RubyMine2026.1")
+      ensure
+        FileUtils.rm_rf(base)
+      end
+    end
+  end
+
   describe ".backup_folder?" do
     it "detects .bak timestamps" do
       Utils.backup_folder?("WebStorm2025.2.bak.1700000000").should be_true

--- a/jb_updater/spec/utils_spec.cr
+++ b/jb_updater/spec/utils_spec.cr
@@ -1,4 +1,5 @@
 require "./spec_helper"
+require "compress/zip"
 include JBUpdater
 
 describe Utils do
@@ -88,6 +89,59 @@ describe Utils do
 
     it "accepts regular folders" do
       Utils.backup_folder?("WebStorm2025.2").should be_false
+    end
+  end
+
+  describe ".read_zip_file" do
+    it "reads a deflated entry from a zip without Compress::Zip parsing" do
+      with_tmpdir do |dir|
+        zip_path = File.join(dir, "archive.zip")
+        File.open(zip_path, "w") do |io|
+          Compress::Zip::Writer.open(io) do |zip|
+            zip.add("plugin/META-INF/plugin.xml") { |e| e.print "<idea-plugin><id>org.test</id></idea-plugin>" }
+          end
+        end
+
+        content = Utils.read_zip_file(zip_path, "plugin/META-INF/plugin.xml")
+        content.should_not be_nil
+        content.try(&.should contain "org.test")
+      end
+    end
+
+    it "returns nil for a missing entry" do
+      with_tmpdir do |dir|
+        zip_path = File.join(dir, "archive.zip")
+        File.open(zip_path, "w") do |io|
+          Compress::Zip::Writer.open(io) do |zip|
+            zip.add("plugin/file.txt") { |e| e.print "x" }
+          end
+        end
+
+        Utils.read_zip_file(zip_path, "no/such.xml").should be_nil
+      end
+    end
+
+    it "returns nil when the zip file does not exist" do
+      Utils.read_zip_file("/tmp/does-not-exist.zip", "plugin.xml").should be_nil
+    end
+  end
+
+  describe ".extract_zip" do
+    it "extracts a single-root archive into the destination" do
+      with_tmpdir do |dir|
+        zip_path = File.join(dir, "archive.zip")
+        File.open(zip_path, "w") do |io|
+          Compress::Zip::Writer.open(io) do |zip|
+            zip.add("plugin1/lib/a.jar") { |e| e.print "jar-bytes" }
+          end
+        end
+
+        dest = File.join(dir, "dest")
+        Utils.extract_zip(zip_path, dest)
+
+        File.exists?(File.join(dest, "lib", "a.jar")).should be_true
+        File.read(File.join(dest, "lib", "a.jar")).should eq "jar-bytes"
+      end
     end
   end
 end

--- a/jb_updater/src/gui/main_gui.cr
+++ b/jb_updater/src/gui/main_gui.cr
@@ -44,6 +44,10 @@ module App
   @@installed_plugins_arr : Array(JBUpdater::PluginMeta) = [] of JBUpdater::PluginMeta
   @@installed_table : UIng::Table? = nil
   @@installed_model : UIng::Table::Model? = nil
+  @@ide_releases : Array(JBUpdater::IDERelease) = [] of JBUpdater::IDERelease
+  @@ide_selected_row : Int32 = -1
+  @@ide_release_table : UIng::Table? = nil
+  @@ide_release_model : UIng::Table::Model? = nil
 
   # Background operation state
   @@op_status : String = ""
@@ -232,6 +236,38 @@ module App
     @@installed_model = model
   end
 
+  def self.ide_releases
+    @@ide_releases
+  end
+
+  def self.ide_releases=(releases : Array(JBUpdater::IDERelease))
+    @@ide_releases = releases
+  end
+
+  def self.ide_selected_row
+    @@ide_selected_row
+  end
+
+  def self.ide_selected_row=(row : Int32)
+    @@ide_selected_row = row
+  end
+
+  def self.ide_release_table
+    @@ide_release_table
+  end
+
+  def self.ide_release_table=(table : UIng::Table?)
+    @@ide_release_table = table
+  end
+
+  def self.ide_release_model
+    @@ide_release_model
+  end
+
+  def self.ide_release_model=(model : UIng::Table::Model?)
+    @@ide_release_model = model
+  end
+
   def self.browse_detail
     @@browse_detail
   end
@@ -412,58 +448,68 @@ private def build_args(
   args
 end
 
-# Locates the `jb_updater` executable (for subprocess invocation).
+# Cached CPU architecture, detected once on the main context at startup.
 #
-# Checks `Process.executable_path`, then CWD, then `JB_UPDATER` env var.
-#
-# @return [String] Path to the executable
-private def jb_exe_path : String
-  exe_path = Process.executable_path
-  if exe_path.nil?
-    App.log.append("[GUI] WARN: Process.executable_path is nil, trying CWD\n")
-    return "./jb_updater" if File::Info.executable?("./jb_updater")
-    return ENV["JB_UPDATER"]? || "jb_updater"
+# `uname -m` runs through `Process.run`, which only works on the main
+# execution context; caching keeps it out of background threads.
+ARCH = begin
+  io = IO::Memory.new
+  status = Process.run("uname", args: ["-m"], output: io)
+  machine = io.to_s.strip
+  if status.success? && (machine == "arm64" || machine == "aarch64")
+    "arm"
+  else
+    "intel"
   end
-
-  here = File.dirname(exe_path)
-  cand = File.expand_path(File.join(here, "jb_updater"))
-
-  return cand if File::Info.executable?(cand)
-  return "./jb_updater" if File::Info.executable?("./jb_updater")
-  ENV["JB_UPDATER"]? || "jb_updater"
+rescue
+  "intel"
 end
 
-# Runs `jb_updater` as a subprocess, streaming output to the log.
+# Runs `jb_updater` logic in-process, mirroring {CLI} argument dispatch.
+#
+# Everything runs on a background thread exactly like the legacy
+# subprocess path, but avoids `Process.run` from a spawned thread,
+# which deadlocks under Crystal 1.21 (spawning is main-context only).
+# `Log.*` output and HTTP progress already route to the GUI console
+# and progress bars via the listeners installed at startup.
 #
 # @param args [Array(String)] CLI arguments
 private def run_cli(args : Array(String)) : Nil
   return if App.busy?
 
   App.busy = true
-  exe = jb_exe_path
   App.log.append("[CLI] jb_updater #{args.join(" ")}\n")
 
   Thread.new do
-    output = IO::Memory.new
-    status = Process.run(exe, args: args, output: output, error: output)
+    opts = JBUpdater.parse_cli(args)
 
-    result = output.to_s
-    unless result.empty?
-      result.each_line do |line|
-        UIng.queue_main do
-          next if App.shutting_down?
-          App.log.append("[subprocess] #{line}\n")
-        end
+    if opts.list_ide_releases?
+      product = JBUpdater::Utils.product_code(opts.product || raise "missing --product")
+      arch = opts.arch || ARCH
+      releases = JBUpdater::IDEReleases.fetch(
+        product,
+        channel: "release",
+        downloads_host: opts.ide_downloads_host,
+        arch: arch,
+        latest: false,
+      )
+      JBUpdater::Log.info("Available releases for #{product}:")
+      releases.each do |rel|
+        JBUpdater::Log.info("- #{rel.version} (#{rel.channel}) #{rel.date}  -> #{rel.link}")
       end
+    elsif opts.upgrade_ide?
+      JBUpdater::IDEUpdater.new(opts).run
+    elsif pd = opts.plugins_dir
+      opts.plugins_dir = JBUpdater::Utils.expand_tilde(pd)
+      JBUpdater::Updater.new(opts).run
+    else
+      raise "no operation requested (missing --product, --plugins-dir, or --upgrade-ide)"
     end
 
     UIng.queue_main do
       next if App.shutting_down?
-      App.log.append("[CLI] exit code: #{status.exit_code}\n")
-      if status.success?
-        App.plugin_progress.value = 100
-      end
-      App.status_label.text = status.success? ? "Done (exit #{status.exit_code})" : "Failed (exit #{status.exit_code})"
+      App.log.append("[CLI] finished\n")
+      App.status_label.text = "Done (exit 0)"
       App.busy = false
       App.debug_reenable
     end
@@ -648,7 +694,7 @@ UIng.init
   do_setup_icon_and_keys
 {% end %}
 
-window = UIng::Window.new("JB Updater — JetBrains IDE & Plugin Manager", 1100, 660)
+window = UIng::Window.new("JB Updater — JetBrains IDE & Plugin Manager", 1180, 780)
 
 window.on_closing do
   App.mark_shutting_down
@@ -700,24 +746,18 @@ JBUpdater::Log.listener = ->(msg : String) {
   App.push_log(msg)
 }
 
-{% if flag?(:gui_log) %}
-  sep2 = UIng::Separator.new("horizontal")
-  root.append(sep2, false)
+sep2 = UIng::Separator.new("horizontal")
+root.append(sep2, false)
 
-  actions_row = UIng::Box.new(:horizontal)
-  actions_row.padded = true
+actions_row = UIng::Box.new(:horizontal)
+actions_row.padded = true
 
-  btn_clear_log = UIng::Button.new("Clear console")
-  btn_remove_cache = UIng::Button.new("Remove *.bak* backups")
-  debug_btn = UIng::Button.new("Debug: Re-enable UI")
+btn_remove_cache = UIng::Button.new("Remove *.bak* backups")
+debug_btn = UIng::Button.new("Debug: Re-enable UI")
 
-  actions_row.append(btn_clear_log, false)
-  actions_row.append(btn_remove_cache, false)
-  actions_row.append(debug_btn, false)
-  root.append(actions_row, false)
-
-  root.append(log, true)
-{% end %}
+actions_row.append(btn_remove_cache, false)
+actions_row.append(debug_btn, false)
+root.append(actions_row, false)
 
 status_label = UIng::Label.new("Ready")
 App.status_label = status_label
@@ -726,22 +766,12 @@ status_box.padded = true
 status_box.append(status_label, true)
 root.append(status_box, false)
 
-{% if flag?(:gui_log) %}
-  btn_clear_log.on_clicked do
-    UIng.queue_main do
-      log.text = ""
-      log.append("Console cleared at #{Time.local}\n")
-      status_label.text = "Console cleared"
-    end
+debug_btn.on_clicked do
+  UIng.queue_main do
+    App.debug_reenable
+    status_label.text = "UI re-enabled"
   end
-
-  debug_btn.on_clicked do
-    UIng.queue_main do
-      App.debug_reenable
-      status_label.text = "UI re-enabled"
-    end
-  end
-{% end %}
+end
 
 # --- Plugins tab ----------------------------------------------------
 plugins_tab = UIng::Box.new(:vertical)
@@ -1114,15 +1144,54 @@ ide_tab.append(ide_group, false)
 chk_brew = UIng::Checkbox.new("Patch Homebrew cask (macOS)")
 ide_tab.append(chk_brew, false)
 
-ide_actions = UIng::Box.new(:vertical)
-ide_actions.padded = true
-
 btn_list_releases = UIng::Button.new("List releases")
+btn_download_release = UIng::Button.new("Download selected")
 btn_upgrade = UIng::Button.new("Upgrade IDE")
 
+ide_actions = UIng::Box.new(:horizontal)
+ide_actions.padded = true
+
 ide_actions.append(btn_list_releases, false)
+ide_actions.append(btn_download_release, false)
 ide_actions.append(btn_upgrade, false)
 ide_tab.append(ide_actions, false)
+ide_tab.append(UIng::Separator.new("horizontal"), false)
+
+release_title = UIng::Label.new("Releases")
+ide_releases_box = UIng::Box.new(:vertical)
+ide_releases_box.padded = true
+ide_releases_box.append(release_title, false)
+
+ide_release_handler = UIng::Table::Model::Handler.new do
+  num_columns { 4 }
+  column_type { |_col| UIng::Table::Value::Type::String }
+  num_rows { App.ide_releases.size }
+  cell_value do |row, col|
+    rel = App.ide_releases[row]?
+    next UIng::Table::Value.new("") unless rel
+    case col
+    when 0 then UIng::Table::Value.new(rel.version)
+    when 1 then UIng::Table::Value.new(rel.channel)
+    when 2 then UIng::Table::Value.new(rel.date)
+    else        UIng::Table::Value.new(rel.link.to_s)
+    end
+  end
+end
+App.ide_release_model = ide_release_model = UIng::Table::Model.new(ide_release_handler)
+App.ide_release_table = ide_release_table = UIng::Table.new(ide_release_model)
+ide_release_table.header_visible = true
+ide_release_table.selection_mode = :one
+ide_release_table.append_text_column("Version", 0, 110)
+ide_release_table.append_text_column("Channel", 1, 90)
+ide_release_table.append_text_column("Date", 2, 120)
+ide_release_table.append_text_column("Download URL", 3, -1)
+ide_releases_box.append(ide_release_table, true)
+ide_tab.append(ide_releases_box, true)
+
+ide_release_table.on_selection_changed do |selection|
+  App.ide_selected_row = selection.num_rows > 0 ? selection.rows[0] : -1
+end
+
 tabs.append("IDE", ide_tab)
 
 combo_products.on_selected do
@@ -1157,8 +1226,14 @@ App.set_widgets(log, overall_bar, plugin_bar, all_buttons)
 
 # Global timer: drain buffered log messages and update progress bars
 UIng.timer(150) do
-  App.drain_log_buffer.each do |msg|
-    App.log.append(msg + "\n")
+  msgs = App.drain_log_buffer
+  if !msgs.empty?
+    if (App.log.text.try(&.size) || 0) > 60_000
+      App.log.text = "… (older log trimmed)\n"
+    end
+    msgs.each do |msg|
+      App.log.append(msg + "\n")
+    end
   end
   pct = App.read_progress
   App.plugin_progress.value = pct if pct > 0
@@ -1178,46 +1253,44 @@ end
 log.append("JB Updater GUI ready. Select a detected IDE or enter paths manually.\n")
 status_label.text = "Ready"
 
-{% if flag?(:gui_log) %}
-  btn_remove_cache.on_clicked do
-    UIng.queue_main do
-      raw = e_plugins_dir.text
-      if raw.nil? || raw.empty?
-        log.append("ERROR: Plugins dir is required for Remove cache.\n")
-        status_label.text = "Error: missing plugins dir"
+btn_remove_cache.on_clicked do
+  UIng.queue_main do
+    raw = e_plugins_dir.text
+    if raw.nil? || raw.empty?
+      log.append("ERROR: Plugins dir is required for Remove cache.\n")
+      status_label.text = "Error: missing plugins dir"
+    else
+      plugins_dir = expand_tilde(raw) || raw
+      if !Dir.exists?(plugins_dir)
+        log.append("ERROR: Plugins dir '#{plugins_dir}' does not exist.\n")
+        status_label.text = "Error: dir not found"
       else
-        plugins_dir = expand_tilde(raw) || raw
-        if !Dir.exists?(plugins_dir)
-          log.append("ERROR: Plugins dir '#{plugins_dir}' does not exist.\n")
-          status_label.text = "Error: dir not found"
-        else
-          begin
-            removed = 0
-            Dir.each_child(plugins_dir) do |entry|
-              if entry.includes?(".bak")
-                path = File.join(plugins_dir, entry)
-                FileUtils.rm_rf(path)
-                removed += 1
-                log.append("Removed backup: #{path}\n")
-              end
+        begin
+          removed = 0
+          Dir.each_child(plugins_dir) do |entry|
+            if entry.includes?(".bak")
+              path = File.join(plugins_dir, entry)
+              FileUtils.rm_rf(path)
+              removed += 1
+              log.append("Removed backup: #{path}\n")
             end
-
-            if removed == 0
-              log.append("No *.bak* backup entries found under #{plugins_dir}\n")
-              status_label.text = "No backups found"
-            else
-              log.append("Removed #{removed} backup entr#{removed == 1 ? "y" : "ies"} under #{plugins_dir}\n")
-              status_label.text = "Removed #{removed} backup(s)"
-            end
-          rescue ex
-            log.append("ERROR while removing cache: #{ex.class}: #{ex.message}\n")
-            status_label.text = "Error during cache removal"
           end
+
+          if removed == 0
+            log.append("No *.bak* backup entries found under #{plugins_dir}\n")
+            status_label.text = "No backups found"
+          else
+            log.append("Removed #{removed} backup entr#{removed == 1 ? "y" : "ies"} under #{plugins_dir}\n")
+            status_label.text = "Removed #{removed} backup(s)"
+          end
+        rescue ex
+          log.append("ERROR while removing cache: #{ex.class}: #{ex.message}\n")
+          status_label.text = "Error during cache removal"
         end
       end
     end
   end
-{% end %}
+end
 
 btn_list.on_clicked do
   UIng.queue_main do
@@ -1277,10 +1350,91 @@ btn_list_releases.on_clicked do
       log.append("ERROR: IDE code is required for List releases (e.g., WS, RM).\n")
       status_label.text = "Error: missing IDE code"
     else
-      args = ["--list-ide-releases", "--product", product]
-      new_run_header("List IDE releases", args)
-      run_cli(args)
+      code = JBUpdater::Utils.product_code(product)
+      new_run_header("List IDE releases", ["--list-ide-releases", "--product", product])
+
+      App.busy = true
+      Thread.new do
+        releases = JBUpdater::IDEReleases.fetch(
+          code,
+          channel: "release",
+          arch: ARCH,
+          latest: false,
+        )
+        UIng.queue_main do
+          next if App.shutting_down?
+          old = App.ide_releases.size
+          App.ide_releases = releases
+          model = App.ide_release_model
+          if model
+            if old == 0
+              releases.each_with_index { |_, i| model.row_inserted(i) }
+            elsif releases.size >= old
+              (0...old).each { |i| model.row_changed(i) }
+              (old...releases.size).each { |i| model.row_inserted(i) }
+            else
+              (0...releases.size).each { |i| model.row_changed(i) }
+              (releases.size...old).reverse_each { |i| model.row_deleted(i) }
+            end
+          end
+          status_label.text = "Found #{releases.size} release(s) for #{code}"
+          log.append("[IDE] #{releases.size} release(s) for #{code}\n")
+        end
+      rescue ex
+        UIng.queue_main do
+          next if App.shutting_down?
+          log.append("[CLI] ERROR: #{ex.message}\n")
+          status_label.text = "Error: #{ex.message}"
+        end
+      ensure
+        UIng.queue_main do
+          next if App.shutting_down?
+          App.busy = false
+          App.debug_reenable
+        end
+      end
+
       save_ide_settings(e_ide_product, e_ide_path, chk_brew)
+    end
+  end
+end
+
+btn_download_release.on_clicked do
+  UIng.queue_main do
+    row = App.ide_selected_row
+    rel = row >= 0 ? App.ide_releases[row]? : nil
+    if rel.nil?
+      status_label.text = "Select a release first"
+      next
+    end
+
+    new_run_header("Download #{rel.version}", [rel.link.to_s])
+
+    dest_dir = File.join(ENV["HOME"]? || Dir.tempdir, "Downloads")
+    Dir.mkdir_p(dest_dir) unless Dir.exists?(dest_dir)
+    dest = File.join(dest_dir, File.basename(rel.link.path.to_s))
+
+    App.busy = true
+    JBUpdater::HTTPClient.no_tty_progress_bar = true
+    Thread.new do
+      JBUpdater::HTTPClient.download(rel.link, dest)
+      UIng.queue_main do
+        next if App.shutting_down?
+        status_label.text = "Downloaded to #{dest}"
+        log.append("[IDE] Downloaded #{rel.version} → #{dest}\n")
+      end
+    rescue ex
+      UIng.queue_main do
+        next if App.shutting_down?
+        log.append("[IDE] Download failed: #{ex.class}: #{ex.message}\n")
+        status_label.text = "Download failed: #{ex.message}"
+      end
+    ensure
+      UIng.queue_main do
+        next if App.shutting_down?
+        App.busy = false
+        App.debug_reenable
+      end
     end
   end
 end

--- a/jb_updater/src/gui/main_gui.cr
+++ b/jb_updater/src/gui/main_gui.cr
@@ -775,11 +775,11 @@ debug_btn : UIng::Button? = nil
 actions_row : UIng::Box? = nil
 if dev_mode
   actions_row = UIng::Box.new(:horizontal)
-  actions_row.not_nil!.padded = true
+  actions_row.padded = true
   btn_remove_cache = UIng::Button.new("Remove *.bak* backups")
   debug_btn = UIng::Button.new("Debug: Re-enable UI")
-  actions_row.not_nil!.append(btn_remove_cache.not_nil!, false)
-  actions_row.not_nil!.append(debug_btn.not_nil!, false)
+  actions_row.append(btn_remove_cache, false)
+  actions_row.append(debug_btn, false)
 end
 root.append(actions_row, false) if actions_row
 
@@ -813,8 +813,8 @@ JBUpdater::Log.listener = ->(msg : String) {
   App.push_log(msg)
 }
 
-if dev_mode
-  debug_btn.not_nil!.on_clicked do
+if debug_btn
+  debug_btn.on_clicked do
     UIng.queue_main do
       App.debug_reenable
       status_label.text = "UI re-enabled"
@@ -1334,45 +1334,45 @@ end
 log.append("JB Updater GUI ready. Select a detected IDE or enter paths manually.\n")
 status_label.text = "Ready"
 
-if dev_mode
-  btn_remove_cache.not_nil!.on_clicked do
+if btn_remove_cache
+  btn_remove_cache.on_clicked do
     UIng.queue_main do
-    raw = e_plugins_dir.text
-    if raw.nil? || raw.empty?
-      log.append("ERROR: Plugins dir is required for Remove cache.\n")
-      status_label.text = "Error: missing plugins dir"
-    else
-      plugins_dir = expand_tilde(raw) || raw
-      if !Dir.exists?(plugins_dir)
-        log.append("ERROR: Plugins dir '#{plugins_dir}' does not exist.\n")
-        status_label.text = "Error: dir not found"
+      raw = e_plugins_dir.text
+      if raw.nil? || raw.empty?
+        log.append("ERROR: Plugins dir is required for Remove cache.\n")
+        status_label.text = "Error: missing plugins dir"
       else
-        begin
-          removed = 0
-          Dir.each_child(plugins_dir) do |entry|
-            if entry.includes?(".bak")
-              path = File.join(plugins_dir, entry)
-              FileUtils.rm_rf(path)
-              removed += 1
-              log.append("Removed backup: #{path}\n")
+        plugins_dir = expand_tilde(raw) || raw
+        if !Dir.exists?(plugins_dir)
+          log.append("ERROR: Plugins dir '#{plugins_dir}' does not exist.\n")
+          status_label.text = "Error: dir not found"
+        else
+          begin
+            removed = 0
+            Dir.each_child(plugins_dir) do |entry|
+              if entry.includes?(".bak")
+                path = File.join(plugins_dir, entry)
+                FileUtils.rm_rf(path)
+                removed += 1
+                log.append("Removed backup: #{path}\n")
+              end
             end
-          end
 
-          if removed == 0
-            log.append("No *.bak* backup entries found under #{plugins_dir}\n")
-            status_label.text = "No backups found"
-          else
-            log.append("Removed #{removed} backup entr#{removed == 1 ? "y" : "ies"} under #{plugins_dir}\n")
-            status_label.text = "Removed #{removed} backup(s)"
+            if removed == 0
+              log.append("No *.bak* backup entries found under #{plugins_dir}\n")
+              status_label.text = "No backups found"
+            else
+              log.append("Removed #{removed} backup entr#{removed == 1 ? "y" : "ies"} under #{plugins_dir}\n")
+              status_label.text = "Removed #{removed} backup(s)"
+            end
+          rescue ex
+            log.append("ERROR while removing cache: #{ex.class}: #{ex.message}\n")
+            status_label.text = "Error during cache removal"
           end
-        rescue ex
-          log.append("ERROR while removing cache: #{ex.class}: #{ex.message}\n")
-          status_label.text = "Error during cache removal"
         end
       end
     end
   end
-end
 end
 
 btn_list.on_clicked do

--- a/jb_updater/src/gui/main_gui.cr
+++ b/jb_updater/src/gui/main_gui.cr
@@ -2,6 +2,7 @@ require "../jb_updater"
 require "../jb_updater/detect_products"
 require "../jb_updater/plugin_marketplace"
 require "../jb_updater/gui_actions"
+require "../jb_updater/clipboard"
 require "file_utils"
 require "json"
 require "uing"
@@ -50,6 +51,39 @@ module App
   @@op_mutex : Mutex = Mutex.new
   @@log_buffer : Array(String) = [] of String
   @@log_buffer_mutex : Mutex = Mutex.new
+
+  # Status bar label (bottom of the window).
+  @@status_label : UIng::Label? = nil
+
+  # Two-step uninstall confirmation state.
+  @@pending_uninstall : String? = nil
+  @@pending_uninstall_at : Time::Instant = Time.instant
+
+  def self.status_label : UIng::Label
+    @@status_label || raise "status label not initialized"
+  end
+
+  def self.status_label=(label : UIng::Label)
+    @@status_label = label
+  end
+
+  # Arms a two-step uninstall confirmation for a plugin ID.
+  def self.arm_uninstall(id : String)
+    @@pending_uninstall = id
+    @@pending_uninstall_at = Time.instant
+  end
+
+  # Consumes the confirmation if it matches and is still recent.
+  def self.confirm_uninstall?(id : String) : Bool
+    armed = @@pending_uninstall == id
+    recent = @@pending_uninstall_at.elapsed < 10.seconds
+    @@pending_uninstall = nil
+    armed && recent
+  end
+
+  def self.cancel_uninstall
+    @@pending_uninstall = nil
+  end
 
   # Download progress (set from background thread, read from UI timer)
   @@download_progress : Int32 = 0
@@ -426,7 +460,10 @@ private def run_cli(args : Array(String)) : Nil
     UIng.queue_main do
       next if App.shutting_down?
       App.log.append("[CLI] exit code: #{status.exit_code}\n")
-      App.plugin_progress.value = 100 if status.success?
+      if status.success?
+        App.plugin_progress.value = 100
+      end
+      App.status_label.text = status.success? ? "Done (exit #{status.exit_code})" : "Failed (exit #{status.exit_code})"
       App.busy = false
       App.debug_reenable
     end
@@ -434,6 +471,7 @@ private def run_cli(args : Array(String)) : Nil
     UIng.queue_main do
       next if App.shutting_down?
       App.log.append("[CLI] ERROR: #{ex.message}\n")
+      App.status_label.text = "Error: #{ex.message}"
       App.busy = false
       App.debug_reenable
     end
@@ -682,6 +720,7 @@ JBUpdater::Log.listener = ->(msg : String) {
 {% end %}
 
 status_label = UIng::Label.new("Ready")
+App.status_label = status_label
 status_box = UIng::Box.new(:horizontal)
 status_box.padded = true
 status_box.append(status_label, true)
@@ -903,6 +942,26 @@ browse_status_box.padded = true
 browse_status_box.append(browse_status, true)
 browse_left.append(browse_status_box, false)
 
+# Diff-updates the browse table and status after a fetch completes.
+# Must run on the UI thread (called from UIng.queue_main).
+browse_update = ->(plugins : Array(JBUpdater::PluginInfo), status : String) {
+  if model = App.browse_table_model
+    old_count = App.browse_plugins.size
+    App.browse_plugins = plugins
+    if old_count == 0
+      plugins.each_with_index { |_, i| model.row_inserted(i) }
+    elsif plugins.size >= old_count
+      (0...old_count).each { |i| model.row_changed(i) }
+      (old_count...plugins.size).each { |i| model.row_inserted(i) }
+    else
+      (0...plugins.size).each { |i| model.row_changed(i) }
+      (plugins.size...old_count).reverse_each { |i| model.row_deleted(i) }
+    end
+  end
+  browse_status.text = status
+  App.log.append("[Browse] #{status}\n")
+}
+
 browse_detail_box = UIng::Box.new(:vertical)
 browse_detail_box.padded = true
 detail_label = UIng::Label.new("Plugin Details")
@@ -994,6 +1053,7 @@ btn_scan_installed.on_clicked do
 end
 
 installed_table.on_selection_changed do |selection|
+  App.cancel_uninstall
   if selection.num_rows > 0
     btn_uninstall.enable
   else
@@ -1008,6 +1068,12 @@ btn_uninstall.on_clicked do
       row = sel.rows[0]
       plugin = App.installed_plugins_arr[row]?
       if plugin
+        # Two-step confirmation guards against accidental deletion.
+        unless App.confirm_uninstall?(plugin.id)
+          App.arm_uninstall(plugin.id)
+          installed_status.text = "Click Uninstall again to confirm deleting #{plugin.id}"
+          next
+        end
         FileUtils.rm_rf(plugin.path)
         scanned = JBUpdater::PluginMeta.scan_dir(File.dirname(plugin.path)) rescue nil
         old_count = App.installed_plugins_arr.size
@@ -1070,6 +1136,7 @@ combo_products.on_selected do
         e_plugins_dir.text = dir
       end
       e_product.text = prod.name
+      e_build.text = prod.build
       e_ide_product.text = prod.build
       if path = prod.ide_path
         e_ide_path.text = path
@@ -1261,113 +1328,129 @@ if inst && inst.size > 0
   App.installed_plugins_arr.each_with_index { |_, i| App.installed_model.try &.row_inserted(i) }
 end
 
-# Warm marketplace cache after UI is visible (1s delay)
+# Warm marketplace cache after UI is visible (1s delay).
+# Heavy HTTP + XML parsing runs on a background thread to avoid
+# crashes inside the AppKit timer callback (bug CB1).
 UIng.timer(1_000) do
   build = resolve_build.call
-  JBUpdater::PluginMarketplace.list_by_build(build)
-  log.append("[Browse] Marketplace cache warmed: #{build}\n")
+  Thread.new do
+    JBUpdater::PluginMarketplace.list_by_build(build)
+    UIng.queue_main do
+      next if App.shutting_down?
+      log.append("[Browse] Marketplace cache warmed: #{build}\n")
+    end
+  rescue ex
+    UIng.queue_main do
+      next if App.shutting_down?
+      log.append("[Browse] Cache warm failed: #{ex.class}: #{ex.message}\n")
+    end
+  end
   0
 end
 
 search_entry.on_changed do |text|
   query = text || ""
+  App.search_id += 1
+  my_id = App.search_id
+
   if query.empty?
-    model = App.browse_table_model
-    if model
+    if model = App.browse_table_model
       old_count = App.browse_plugins.size
       App.browse_plugins = [] of JBUpdater::PluginInfo
       (0...old_count).each { |i| model.row_deleted(0) }
     end
     App.selected_xml_id = nil
     browse_status.text = "Type to search plugins..."
-    next
-  end
-
-  build = resolve_build.call
-  plugins = JBUpdater::PluginMarketplace.search(query, build)
-
-  model = App.browse_table_model
-  next unless model
-
-  old_count = App.browse_plugins.size
-  App.browse_plugins = plugins
-  if old_count == 0
-    plugins.each_with_index { |_, i| model.row_inserted(i) }
-  elsif plugins.size >= old_count
-    (0...old_count).each { |i| model.row_changed(i) }
-    (old_count...plugins.size).each { |i| model.row_inserted(i) }
   else
-    (0...plugins.size).each { |i| model.row_changed(i) }
-    (plugins.size...old_count).reverse_each { |i| model.row_deleted(i) }
+    build = resolve_build.call
+    browse_status.text = "Searching..."
+    # Filtering runs on a background thread and is debounced so rapid
+    # keystrokes only trigger the final query (bug CB2).
+    Thread.new do
+      sleep 250.milliseconds
+      if my_id == App.search_id
+        begin
+          plugins = JBUpdater::PluginMarketplace.search(query, build)
+          UIng.queue_main do
+            next if App.shutting_down?
+            if my_id == App.search_id
+              browse_update.call(plugins, "Found #{plugins.size} results")
+            end
+          end
+        rescue ex
+          UIng.queue_main do
+            next if App.shutting_down?
+            if my_id == App.search_id
+              App.log.append("[Browse] Search error: #{ex.class}: #{ex.message}\n")
+              browse_status.text = "Search error: #{ex.message}"
+            end
+          end
+        end
+      end
+    end
   end
-  browse_status.text = "Found #{plugins.size} results"
 rescue ex
-  log.append("[Browse] Search error: #{ex.class}: #{ex.message}\n")
-  browse_status.text = "Search error: #{ex.class} #{ex.message}"
+  App.log.append("[Browse] Search error: #{ex.class}: #{ex.message}\n")
+  browse_status.text = "Search error: #{ex.message}"
 end
 
 btn_top.on_clicked do
   build = resolve_build.call
-  browse_status.text = "Fetching top plugins (may lag)..."
+  App.search_id += 1
+  browse_status.text = "Fetching top plugins..."
   log.append("[Browse] Fetching top downloaded for build #{build}...\n")
-  plugins = JBUpdater::PluginMarketplace.top_downloaded(build, 100)
-  log.append("[Browse] Got #{plugins.size} plugins, updating table...\n")
-  plugins.first(3).each { |plugin| log.append("  #{plugin.name} (#{plugin.downloads} dl)\n") }
-
-  model = App.browse_table_model
-  next unless model
-
-  old_count = App.browse_plugins.size
-  App.browse_plugins = plugins
-  if old_count == 0
-    plugins.each_with_index { |_, i| model.row_inserted(i) }
-  elsif plugins.size >= old_count
-    (0...old_count).each { |i| model.row_changed(i) }
-    (old_count...plugins.size).each { |i| model.row_inserted(i) }
-  else
-    (0...plugins.size).each { |i| model.row_changed(i) }
-    (plugins.size...old_count).reverse_each { |i| model.row_deleted(i) }
+  Thread.new do
+    plugins = JBUpdater::PluginMarketplace.top_downloaded(build, 100)
+    UIng.queue_main do
+      next if App.shutting_down?
+      plugins.first(3).each { |plugin| log.append("  #{plugin.name} (#{plugin.downloads} dl)\n") }
+      browse_update.call(plugins, "Loaded #{plugins.size} plugins (top downloads)")
+    end
+  rescue ex
+    UIng.queue_main do
+      next if App.shutting_down?
+      log.append("[Browse] Top downloads error: #{ex.class}: #{ex.message}\n")
+      browse_status.text = "Error: #{ex.message}"
+    end
   end
-  browse_status.text = "Loaded #{plugins.size} plugins (top downloads)"
 end
 
 btn_newest.on_clicked do
   build = resolve_build.call
+  App.search_id += 1
   browse_status.text = "Fetching latest plugins..."
   log.append("[Browse] Fetching newest for build #{build}...\n")
-  plugins = JBUpdater::PluginMarketplace.newest(build, 100)
-  log.append("[Browse] Got #{plugins.size} plugins, updating table...\n")
-  plugins.first(3).each { |plugin| log.append("  #{plugin.name} (#{plugin.downloads} dl)\n") }
-
-  model = App.browse_table_model
-  next unless model
-
-  old_count = App.browse_plugins.size
-  App.browse_plugins = plugins
-  if old_count == 0
-    plugins.each_with_index { |_, i| model.row_inserted(i) }
-  elsif plugins.size >= old_count
-    (0...old_count).each { |i| model.row_changed(i) }
-    (old_count...plugins.size).each { |i| model.row_inserted(i) }
-  else
-    (0...plugins.size).each { |i| model.row_changed(i) }
-    (plugins.size...old_count).each { |i| model.row_deleted(i) }
+  Thread.new do
+    plugins = JBUpdater::PluginMarketplace.newest(build, 100)
+    UIng.queue_main do
+      next if App.shutting_down?
+      plugins.first(3).each { |plugin| log.append("  #{plugin.name} (#{plugin.downloads} dl)\n") }
+      browse_update.call(plugins, "Loaded #{plugins.size} plugins (latest)")
+    end
+  rescue ex
+    UIng.queue_main do
+      next if App.shutting_down?
+      log.append("[Browse] Newest error: #{ex.class}: #{ex.message}\n")
+      browse_status.text = "Error: #{ex.message}"
+    end
   end
-  browse_status.text = "Loaded #{plugins.size} plugins (latest)"
 end
 
 btn_refresh.on_clicked do
   UIng.queue_main do
+    App.search_id += 1
     App.installed_plugins = nil
-    model = App.browse_table_model
-    if model
+    App.selected_xml_id = nil
+    JBUpdater::PluginMarketplace.clear_cache
+    if model = App.browse_table_model
       old_count = App.browse_plugins.size
       (0...old_count).each { |i| model.row_deleted(i) }
       App.browse_plugins = [] of JBUpdater::PluginInfo
-      App.selected_xml_id = nil
-      JBUpdater::PluginMarketplace.clear_cache
-      browse_status.text = "Cache cleared. Click Top/Refresh to reload."
     end
+    browse_status.text = "Cache cleared. Click Top/Refresh to reload."
+  rescue ex
+    log.append("[Browse] Refresh error: #{ex.class}: #{ex.message}\n")
+    browse_status.text = "Refresh error: #{ex.message}"
   end
 end
 
@@ -1411,8 +1494,9 @@ btn_copy_id.on_clicked do
   if xml_id.nil? || xml_id.empty?
     browse_status.text = "Please select a plugin first"
   else
-    log.append("[Browse] Copied XML ID: #{xml_id}\n")
-    browse_status.text = "Copied to clipboard: #{xml_id}"
+    copied = JBUpdater::Clipboard.copy(xml_id)
+    log.append("[Browse] Copied XML ID: #{xml_id} (#{copied ? "ok" : "failed"})\n")
+    browse_status.text = copied ? "Copied to clipboard: #{xml_id}" : "Copy to clipboard failed: #{xml_id}"
   end
 end
 

--- a/jb_updater/src/gui/main_gui.cr
+++ b/jb_updater/src/gui/main_gui.cr
@@ -71,6 +71,16 @@ module App
     @@status_label = label
   end
 
+  @@ide_badge : UIng::Label? = nil
+
+  def self.ide_badge : UIng::Label?
+    @@ide_badge
+  end
+
+  def self.ide_badge=(label : UIng::Label)
+    @@ide_badge = label
+  end
+
   # Arms a two-step uninstall confirmation for a plugin ID.
   def self.arm_uninstall(id : String)
     @@pending_uninstall = id
@@ -670,6 +680,20 @@ private def apply_plugins_settings(
   end
 end
 
+# Updates the global "Current IDE" badge shown on every tab.
+private def update_ide_badge(e_product : UIng::Entry, e_build : UIng::Entry) : Nil
+  return unless App.ide_badge
+  product = e_product.text.try(&.strip)
+  build = e_build.text.try(&.strip)
+  if product.nil? || product.empty?
+    App.ide_badge.try(&.text = "")
+  elsif build.nil? || build.empty?
+    App.ide_badge.try(&.text = "Current IDE: #{product}")
+  else
+    App.ide_badge.try(&.text = "Current IDE: #{product} (#{build})")
+  end
+end
+
 # Restores IDE tab field values from saved config.
 private def apply_ide_settings(
   e_ide_product : UIng::Entry,
@@ -744,21 +768,30 @@ root.append(pb_group, false)
 sep1 = UIng::Separator.new("horizontal")
 root.append(sep1, false)
 
-actions_row = UIng::Box.new(:horizontal)
-actions_row.padded = true
-
-btn_remove_cache = UIng::Button.new("Remove *.bak* backups")
-debug_btn = UIng::Button.new("Debug: Re-enable UI")
-
-actions_row.append(btn_remove_cache, false)
-actions_row.append(debug_btn, false)
-root.append(actions_row, false)
+# Dev-only conveniences (hidden unless JB_UPDATER_DEV is set).
+dev_mode = ENV["JB_UPDATER_DEV"]? == "1"
+btn_remove_cache : UIng::Button? = nil
+debug_btn : UIng::Button? = nil
+actions_row : UIng::Box? = nil
+if dev_mode
+  actions_row = UIng::Box.new(:horizontal)
+  actions_row.not_nil!.padded = true
+  btn_remove_cache = UIng::Button.new("Remove *.bak* backups")
+  debug_btn = UIng::Button.new("Debug: Re-enable UI")
+  actions_row.not_nil!.append(btn_remove_cache.not_nil!, false)
+  actions_row.not_nil!.append(debug_btn.not_nil!, false)
+end
+root.append(actions_row, false) if actions_row
 
 status_label = UIng::Label.new("Ready")
 App.status_label = status_label
 status_box = UIng::Box.new(:horizontal)
 status_box.padded = true
 status_box.append(status_label, false)
+ide_badge = UIng::Label.new("")
+App.ide_badge = ide_badge
+status_box.append(UIng::Box.new(:horizontal), true)
+status_box.append(ide_badge, false)
 root.append(status_box, false)
 
 sep2 = UIng::Separator.new("horizontal")
@@ -780,10 +813,12 @@ JBUpdater::Log.listener = ->(msg : String) {
   App.push_log(msg)
 }
 
-debug_btn.on_clicked do
-  UIng.queue_main do
-    App.debug_reenable
-    status_label.text = "UI re-enabled"
+if dev_mode
+  debug_btn.not_nil!.on_clicked do
+    UIng.queue_main do
+      App.debug_reenable
+      status_label.text = "UI re-enabled"
+    end
   end
 end
 
@@ -827,13 +862,19 @@ combo_arch.selected = 0
 config_form.append("Plugins dir", e_plugins_dir, true)
 config_form.append("Build", e_build, false)
 config_form.append("Product", e_product, false)
-config_form.append("Install IDs", e_install_ids, false)
 config_form.append("Arch", combo_arch, false)
 config_group.child = config_form
 plugins_tab.append(config_group, false)
 
 chk_dry = UIng::Checkbox.new("Dry run")
 plugins_tab.append(chk_dry, false)
+
+install_ids_row = UIng::Box.new(:horizontal)
+install_ids_row.padded = true
+ids_label = UIng::Label.new("Install XML IDs")
+install_ids_row.append(ids_label, false)
+install_ids_row.append(e_install_ids, true)
+plugins_tab.append(install_ids_row, false)
 
 btn_group = UIng::Box.new(:vertical)
 btn_group.padded = true
@@ -869,6 +910,7 @@ btn_group.append(btn_detect, false)
 btn_group_sep = UIng::Separator.new("horizontal")
 btn_group.append(btn_group_sep, false)
 
+batch_group = UIng::Group.new("Bulk actions", margined: true)
 main_actions = UIng::Box.new(:horizontal)
 main_actions.padded = true
 
@@ -879,11 +921,11 @@ btn_update = UIng::Button.new("Update all")
 main_actions.append(btn_list, false)
 main_actions.append(btn_install, false)
 main_actions.append(btn_update, false)
-btn_group.append(main_actions, false)
+batch_group.child = main_actions
+btn_group.append(batch_group, false)
 
 plugins_tab.append(btn_group, false)
-plugins_tab.append(UIng::Box.new(:vertical), true)
-tabs.append("Plugins", plugins_tab)
+tabs.append("Main", plugins_tab)
 
 # --- Browse tab -----------------------------------------------------
 browse_tab = UIng::Box.new(:vertical)
@@ -1241,9 +1283,11 @@ combo_products.on_selected do
       end
 
       status_label.text = "Selected: #{prod.name}"
+      update_ide_badge(e_product, e_build)
       save_plugins_settings(e_plugins_dir, e_build, e_product, e_install_ids, combo_arch, combo_products, chk_dry)
     else
       status_label.text = "Product selection: manual/custom"
+      update_ide_badge(e_product, e_build)
     end
   end
 end
@@ -1278,12 +1322,21 @@ if idx > 0 && idx <= detected.size
   e_ide_product.text = prod.build
   log.append("[GUI] Restored product: #{prod.name} (#{prod.build})\n")
 end
+update_ide_badge(e_product, e_build)
+
+e_product.on_changed do |_|
+  UIng.queue_main { update_ide_badge(e_product, e_build) }
+end
+e_build.on_changed do |_|
+  UIng.queue_main { update_ide_badge(e_product, e_build) }
+end
 
 log.append("JB Updater GUI ready. Select a detected IDE or enter paths manually.\n")
 status_label.text = "Ready"
 
-btn_remove_cache.on_clicked do
-  UIng.queue_main do
+if dev_mode
+  btn_remove_cache.not_nil!.on_clicked do
+    UIng.queue_main do
     raw = e_plugins_dir.text
     if raw.nil? || raw.empty?
       log.append("ERROR: Plugins dir is required for Remove cache.\n")
@@ -1319,6 +1372,7 @@ btn_remove_cache.on_clicked do
       end
     end
   end
+end
 end
 
 btn_list.on_clicked do
@@ -1673,10 +1727,10 @@ btn_refresh.on_clicked do
     JBUpdater::PluginMarketplace.clear_cache
     if model = App.browse_table_model
       old_count = App.browse_plugins.size
-      (0...old_count).each { |i| model.row_deleted(i) }
+      (0...old_count).each { |_| model.row_deleted(0) }
       App.browse_plugins = [] of JBUpdater::PluginInfo
     end
-    browse_status.text = "Cache cleared. Click Top/Refresh to reload."
+    browse_status.text = "Cache cleared. Click Top Downloaded or Newest to reload."
   rescue ex
     log.append("[Browse] Refresh error: #{ex.class}: #{ex.message}\n")
     browse_status.text = "Refresh error: #{ex.message}"
@@ -1707,7 +1761,7 @@ btn_install_browse.on_clicked do
 
   plugins_dir = e_plugins_dir.text
   if plugins_dir.nil? || plugins_dir.empty?
-    browse_status.text = "Error: plugins dir not set. Switch to Plugins tab."
+    browse_status.text = "Error: plugins dir not set. Switch to Main tab."
     next
   end
 

--- a/jb_updater/src/gui/main_gui.cr
+++ b/jb_updater/src/gui/main_gui.cr
@@ -433,13 +433,14 @@ private def build_args(
   combo_arch : UIng::Combobox,
   chk_dry : UIng::Checkbox,
   chk_list : UIng::Checkbox,
+  include_install : Bool = true,
 ) : Array(String)
   args = [] of String
 
   add_opt(args, "--plugins-dir", expand_tilde(e_plugins_dir.text))
   add_opt(args, "--build", e_build.text)
   add_opt(args, "--product", e_product.text)
-  add_opt(args, "--install-plugin", e_install_ids.text)
+  add_opt(args, "--install-plugin", e_install_ids.text) if include_install
 
   args.concat(arch_args(combo_arch))
 
@@ -482,6 +483,7 @@ private def run_cli(args : Array(String)) : Nil
 
   Thread.new do
     opts = JBUpdater.parse_cli(args)
+    opts.arch ||= ARCH
 
     if opts.list_ide_releases?
       product = JBUpdater::Utils.product_code(opts.product || raise "missing --product")
@@ -584,10 +586,22 @@ private def queue_install(xml_id : String, plugins_dir : String, build : String)
 
     JBUpdater::GUI::Actions.processing = false
     UIng.queue_main do
+      next if App.shutting_down?
       App.plugin_progress.value = 100
       App.overall_progress.value = 100
       App.busy = false
       App.debug_reenable
+
+      # Push installation results into the Installed tab and Browse
+      # "Installed" column so the user sees the plugin right away.
+      scanned = JBUpdater::PluginMeta.scan_dir(plugins_dir) rescue nil
+      if scanned
+        apply_installed_scan(scanned)
+        App.status_label.text = "Installed. Found #{scanned.size} installed plugins"
+      end
+      if model = App.browse_table_model
+        (0...App.browse_plugins.size).each { |i| model.row_changed(i) }
+      end
     end
   end
 end
@@ -694,7 +708,7 @@ UIng.init
   do_setup_icon_and_keys
 {% end %}
 
-window = UIng::Window.new("JB Updater — JetBrains IDE & Plugin Manager", 1180, 780)
+window = UIng::Window.new("JB Updater — JetBrains IDE & Plugin Manager", 1180, 840)
 
 window.on_closing do
   App.mark_shutting_down
@@ -730,6 +744,26 @@ root.append(pb_group, false)
 sep1 = UIng::Separator.new("horizontal")
 root.append(sep1, false)
 
+actions_row = UIng::Box.new(:horizontal)
+actions_row.padded = true
+
+btn_remove_cache = UIng::Button.new("Remove *.bak* backups")
+debug_btn = UIng::Button.new("Debug: Re-enable UI")
+
+actions_row.append(btn_remove_cache, false)
+actions_row.append(debug_btn, false)
+root.append(actions_row, false)
+
+status_label = UIng::Label.new("Ready")
+App.status_label = status_label
+status_box = UIng::Box.new(:horizontal)
+status_box.padded = true
+status_box.append(status_label, false)
+root.append(status_box, false)
+
+sep2 = UIng::Separator.new("horizontal")
+root.append(sep2, false)
+
 tabs = UIng::Tab.new
 root.append(tabs, true)
 
@@ -745,26 +779,6 @@ JBUpdater::HTTPClient.on_progress = ->(downloaded : Int64, total : Int64) {
 JBUpdater::Log.listener = ->(msg : String) {
   App.push_log(msg)
 }
-
-sep2 = UIng::Separator.new("horizontal")
-root.append(sep2, false)
-
-actions_row = UIng::Box.new(:horizontal)
-actions_row.padded = true
-
-btn_remove_cache = UIng::Button.new("Remove *.bak* backups")
-debug_btn = UIng::Button.new("Debug: Re-enable UI")
-
-actions_row.append(btn_remove_cache, false)
-actions_row.append(debug_btn, false)
-root.append(actions_row, false)
-
-status_label = UIng::Label.new("Ready")
-App.status_label = status_label
-status_box = UIng::Box.new(:horizontal)
-status_box.padded = true
-status_box.append(status_label, true)
-root.append(status_box, false)
 
 debug_btn.on_clicked do
   UIng.queue_main do
@@ -827,6 +841,10 @@ btn_group.padded = true
 btn_detect = UIng::Button.new("Detect from Product")
 btn_detect.on_clicked do
   UIng.queue_main do
+    if App.busy?
+      status_label.text = "Already running… please wait"
+      next
+    end
     product = e_product.text
     if product.nil? || product.empty?
       log.append("ERROR: Enter Product (e.g., RubyMine2025.2) before Detect.\n")
@@ -864,6 +882,7 @@ main_actions.append(btn_update, false)
 btn_group.append(main_actions, false)
 
 plugins_tab.append(btn_group, false)
+plugins_tab.append(UIng::Box.new(:vertical), true)
 tabs.append("Plugins", plugins_tab)
 
 # --- Browse tab -----------------------------------------------------
@@ -1056,6 +1075,24 @@ installed_tab.append(installed_status, false)
 
 tabs.append("Installed", installed_tab)
 
+# Applies a fresh PluginMeta scan to the Installed tab table (UI thread).
+private def apply_installed_scan(scanned : Hash(String, JBUpdater::PluginMeta)) : Nil
+  old_count = App.installed_plugins_arr.size
+  App.installed_plugins = scanned
+  model = App.installed_model
+  return unless model
+  if old_count == 0
+    App.installed_plugins_arr.each_with_index { |_, i| model.row_inserted(i) }
+  else
+    (0...[App.installed_plugins_arr.size, old_count].min).each { |i| model.row_changed(i) }
+    if App.installed_plugins_arr.size > old_count
+      (old_count...App.installed_plugins_arr.size).each { |i| model.row_inserted(i) }
+    elsif App.installed_plugins_arr.size < old_count
+      (App.installed_plugins_arr.size...old_count).reverse_each { |i| model.row_deleted(i) }
+    end
+  end
+end
+
 btn_scan_installed.on_clicked do
   dir = expand_tilde(e_plugins_dir.text) || e_plugins_dir.text || ""
   if dir.empty?
@@ -1064,21 +1101,13 @@ btn_scan_installed.on_clicked do
   end
   scanned = JBUpdater::PluginMeta.scan_dir(dir) rescue nil
   if scanned
-    old_count = App.installed_plugins_arr.size
-    App.installed_plugins = scanned
-    if old_count == 0
-      App.installed_plugins_arr.each_with_index { |_, i| App.installed_model.try &.row_inserted(i) }
-    else
-      (0...[App.installed_plugins_arr.size, old_count].min).each { |i| App.installed_model.try &.row_changed(i) }
-      if App.installed_plugins_arr.size > old_count
-        (old_count...App.installed_plugins_arr.size).each { |i| App.installed_model.try &.row_inserted(i) }
-      elsif App.installed_plugins_arr.size < old_count
-        (App.installed_plugins_arr.size...old_count).reverse_each { |i| App.installed_model.try &.row_deleted(i) }
-      end
-    end
-    installed_status.text = "Found #{scanned.size} installed plugins"
+    apply_installed_scan(scanned)
+    msg = "Found #{scanned.size} installed plugins"
+    installed_status.text = msg
+    status_label.text = msg
   else
     installed_status.text = "Error scanning plugins directory"
+    status_label.text = "Error scanning plugins directory"
   end
 end
 
@@ -1294,57 +1323,95 @@ end
 
 btn_list.on_clicked do
   UIng.queue_main do
+    if App.busy?
+      status_label.text = "Already running… please wait"
+      next
+    end
     raw = e_plugins_dir.text
     if raw.nil? || raw.empty?
       log.append("ERROR: Plugins dir is required for List installed plugins.\n")
       status_label.text = "Error: missing plugins dir"
-    else
-      plugins_dir = expand_tilde(raw)
-      e_plugins_dir.text = plugins_dir if plugins_dir
-      args = build_args(e_plugins_dir, e_build, e_product, e_install_ids, combo_arch, chk_dry, UIng::Checkbox.new("")) + ["--list"]
-      new_run_header("List installed plugins", args)
-      run_cli(args)
-      save_plugins_settings(e_plugins_dir, e_build, e_product, e_install_ids, combo_arch, combo_products, chk_dry)
+      next
     end
+    plugins_dir = expand_tilde(raw) || raw
+    e_plugins_dir.text = plugins_dir
+    new_run_header("List installed plugins", ["--list", "--plugins-dir", plugins_dir])
+    App.busy = true
+    Thread.new do
+      scanned = JBUpdater::PluginMeta.scan_dir(plugins_dir)
+      UIng.queue_main do
+        next if App.shutting_down?
+        apply_installed_scan(scanned)
+        msg = "Found #{scanned.size} installed plugins"
+        installed_status.text = msg
+        status_label.text = msg
+        log.append("[CLI] #{msg}\n")
+        tabs.selected = 2
+        App.busy = false
+        App.debug_reenable
+      end
+    rescue ex
+      UIng.queue_main do
+        next if App.shutting_down?
+        log.append("[CLI] ERROR: #{ex.message}\n")
+        status_label.text = "Error: #{ex.message}"
+        installed_status.text = "Error: #{ex.message}"
+        App.busy = false
+        App.debug_reenable
+      end
+    end
+    save_plugins_settings(e_plugins_dir, e_build, e_product, e_install_ids, combo_arch, combo_products, chk_dry)
   end
 end
 
 btn_install.on_clicked do
   UIng.queue_main do
+    if App.busy?
+      status_label.text = "Already running… please wait"
+      next
+    end
     raw = e_plugins_dir.text
     if raw.nil? || raw.empty?
       log.append("ERROR: Plugins dir is required for Install plugins.\n")
       status_label.text = "Error: missing plugins dir"
-    else
-      plugins_dir = expand_tilde(raw)
-      e_plugins_dir.text = plugins_dir if plugins_dir
-      args = build_args(e_plugins_dir, e_build, e_product, e_install_ids, combo_arch, chk_dry, UIng::Checkbox.new(""))
-      new_run_header("Install plugins", args)
-      run_cli(args)
-      save_plugins_settings(e_plugins_dir, e_build, e_product, e_install_ids, combo_arch, combo_products, chk_dry)
+      next
     end
+    plugins_dir = expand_tilde(raw)
+    e_plugins_dir.text = plugins_dir if plugins_dir
+    args = build_args(e_plugins_dir, e_build, e_product, e_install_ids, combo_arch, chk_dry, UIng::Checkbox.new(""))
+    new_run_header("Install plugins", args)
+    run_cli(args)
+    save_plugins_settings(e_plugins_dir, e_build, e_product, e_install_ids, combo_arch, combo_products, chk_dry)
   end
 end
 
 btn_update.on_clicked do
   UIng.queue_main do
+    if App.busy?
+      status_label.text = "Already running… please wait"
+      next
+    end
     raw = e_plugins_dir.text
     if raw.nil? || raw.empty?
       log.append("ERROR: Plugins dir is required for Update plugins.\n")
       status_label.text = "Error: missing plugins dir"
-    else
-      plugins_dir = expand_tilde(raw)
-      e_plugins_dir.text = plugins_dir if plugins_dir
-      args = build_args(e_plugins_dir, e_build, e_product, e_install_ids, combo_arch, chk_dry, UIng::Checkbox.new(""))
-      new_run_header("Update plugins", args)
-      run_cli(args)
-      save_plugins_settings(e_plugins_dir, e_build, e_product, e_install_ids, combo_arch, combo_products, chk_dry)
+      next
     end
+    plugins_dir = expand_tilde(raw)
+    e_plugins_dir.text = plugins_dir if plugins_dir
+    args = build_args(e_plugins_dir, e_build, e_product, e_install_ids, combo_arch, chk_dry, UIng::Checkbox.new(""), include_install: false)
+    new_run_header("Update plugins", args)
+    run_cli(args)
+    save_plugins_settings(e_plugins_dir, e_build, e_product, e_install_ids, combo_arch, combo_products, chk_dry)
   end
 end
 
 btn_list_releases.on_clicked do
   UIng.queue_main do
+    if App.busy?
+      status_label.text = "Already running… please wait"
+      next
+    end
     product = e_ide_product.text
     if product.nil? || product.empty?
       log.append("ERROR: IDE code is required for List releases (e.g., WS, RM).\n")
@@ -1401,6 +1468,10 @@ end
 
 btn_download_release.on_clicked do
   UIng.queue_main do
+    if App.busy?
+      status_label.text = "Already running… please wait"
+      next
+    end
     row = App.ide_selected_row
     rel = row >= 0 ? App.ide_releases[row]? : nil
     if rel.nil?
@@ -1441,6 +1512,10 @@ end
 
 btn_upgrade.on_clicked do
   UIng.queue_main do
+    if App.busy?
+      status_label.text = "Already running… please wait"
+      next
+    end
     args = ["--upgrade-ide"]
 
     ide_product = e_ide_product.text

--- a/jb_updater/src/gui/main_gui.cr
+++ b/jb_updater/src/gui/main_gui.cr
@@ -957,7 +957,7 @@ browse_model_handler = UIng::Table::Model::Handler.new do
     if row < App.browse_plugins.size
       plugin = App.browse_plugins[row]
       case col
-      when 0 then UIng::Table::Value.new(plugin.name)
+      when 0 then UIng::Table::Value.new(plugin.compat_note ? "⚠ #{plugin.name}" : plugin.name)
       when 1
         installed = App.installed_plugins
         value = installed ? (installed.has_key?(plugin.xml_id) ? "✓" : "") : "—"
@@ -1759,10 +1759,14 @@ browse_table.on_selection_changed do |selection|
   plugin = row >= 0 ? App.browse_plugins[row]? : nil
   if plugin
     App.selected_xml_id = plugin.xml_id
-    stripped = plugin.description[0, 500]
-    preview = stripped[0, 500]
-    App.log.append("[Browse] detail: #{preview.size}B #{preview.count('\n')} lines (#{preview.size - preview.count('\n')} non-newline)\n")
-    App.safe_set_text(browse_detail, preview)
+    if note = plugin.compat_note
+      App.safe_set_text(browse_detail, "⚠ #{note}\n\n#{plugin.description}")
+    else
+      stripped = plugin.description[0, 500]
+      preview = stripped[0, 500]
+      App.log.append("[Browse] detail: #{preview.size}B #{preview.count('\n')} lines (#{preview.size - preview.count('\n')} non-newline)\n")
+      App.safe_set_text(browse_detail, preview)
+    end
   else
     App.safe_set_text(browse_detail, "Select a plugin to view details")
     App.selected_xml_id = nil
@@ -1784,7 +1788,9 @@ btn_install_browse.on_clicked do
 
   build = resolve_build.call
 
-  log.append("[Browse] Installing plugin: #{xml_id} for build #{build}\n")
+  warn = App.browse_plugins.any? { |plugin| plugin.xml_id == xml_id && plugin.compat_note }
+  log.append(warn ? "[Browse] ⚠ #{xml_id} may not be fully compatible with build #{build}; installing latest compatible version\n" : "[Browse] Installing plugin: #{xml_id} for build #{build}\n")
+  browse_status.text = warn ? "Installing (compatibility warning)…" : "Installing…"
 
   queue_install(xml_id, plugins_dir, build)
 end

--- a/jb_updater/src/gui/main_gui.cr
+++ b/jb_updater/src/gui/main_gui.cr
@@ -915,12 +915,8 @@ main_actions = UIng::Box.new(:horizontal)
 main_actions.padded = true
 
 btn_list = UIng::Button.new("List installed")
-btn_install = UIng::Button.new("Install by IDs")
-btn_update = UIng::Button.new("Update all")
 
 main_actions.append(btn_list, false)
-main_actions.append(btn_install, false)
-main_actions.append(btn_update, false)
 batch_group.child = main_actions
 btn_group.append(batch_group, false)
 
@@ -1105,8 +1101,13 @@ installed_actions.padded = true
 btn_scan_installed = UIng::Button.new("Scan")
 btn_uninstall = UIng::Button.new("Uninstall selected")
 btn_uninstall.disable
+btn_update = UIng::Button.new("Update all")
+btn_update_selected = UIng::Button.new("Update selected")
+btn_update_selected.disable
 
 installed_actions.append(btn_scan_installed, false)
+installed_actions.append(btn_update, false)
+installed_actions.append(btn_update_selected, false)
 installed_actions.append(btn_uninstall, false)
 
 installed_status = UIng::Label.new("Click Scan to list installed plugins")
@@ -1157,8 +1158,10 @@ installed_table.on_selection_changed do |selection|
   App.cancel_uninstall
   if selection.num_rows > 0
     btn_uninstall.enable
+    btn_update_selected.enable
   else
     btn_uninstall.disable
+    btn_update_selected.disable
   end
 end
 
@@ -1293,7 +1296,8 @@ combo_products.on_selected do
 end
 
 all_buttons = [] of UIng::Button
-all_buttons.concat([btn_list, btn_install, btn_update])
+all_buttons.concat([btn_list])
+all_buttons.concat([btn_update, btn_update_selected, btn_uninstall])
 all_buttons.concat([btn_list_releases, btn_upgrade])
 App.set_widgets(log, overall_bar, plugin_bar, all_buttons)
 
@@ -1418,27 +1422,6 @@ btn_list.on_clicked do
   end
 end
 
-btn_install.on_clicked do
-  UIng.queue_main do
-    if App.busy?
-      status_label.text = "Already running… please wait"
-      next
-    end
-    raw = e_plugins_dir.text
-    if raw.nil? || raw.empty?
-      log.append("ERROR: Plugins dir is required for Install plugins.\n")
-      status_label.text = "Error: missing plugins dir"
-      next
-    end
-    plugins_dir = expand_tilde(raw)
-    e_plugins_dir.text = plugins_dir if plugins_dir
-    args = build_args(e_plugins_dir, e_build, e_product, e_install_ids, combo_arch, chk_dry, UIng::Checkbox.new(""))
-    new_run_header("Install plugins", args)
-    run_cli(args)
-    save_plugins_settings(e_plugins_dir, e_build, e_product, e_install_ids, combo_arch, combo_products, chk_dry)
-  end
-end
-
 btn_update.on_clicked do
   UIng.queue_main do
     if App.busy?
@@ -1455,6 +1438,40 @@ btn_update.on_clicked do
     e_plugins_dir.text = plugins_dir if plugins_dir
     args = build_args(e_plugins_dir, e_build, e_product, e_install_ids, combo_arch, chk_dry, UIng::Checkbox.new(""), include_install: false)
     new_run_header("Update plugins", args)
+    run_cli(args)
+    save_plugins_settings(e_plugins_dir, e_build, e_product, e_install_ids, combo_arch, combo_products, chk_dry)
+  end
+end
+
+btn_update_selected.on_clicked do
+  UIng.queue_main do
+    if App.busy?
+      status_label.text = "Already running… please wait"
+      next
+    end
+    raw = e_plugins_dir.text
+    if raw.nil? || raw.empty?
+      log.append("ERROR: Plugins dir is required for Update selected plugins.\n")
+      status_label.text = "Error: missing plugins dir"
+      next
+    end
+    ids = [] of String
+    installed_table.selection do |sel|
+      sel.rows.each do |row|
+        plugin = App.installed_plugins_arr[row]?
+        ids << plugin.id if plugin
+      end
+    end
+    if ids.empty?
+      installed_status.text = "Select at least one installed plugin to update"
+      status_label.text = "No plugin selected"
+      next
+    end
+    plugins_dir = expand_tilde(raw)
+    e_plugins_dir.text = plugins_dir if plugins_dir
+    args = build_args(e_plugins_dir, e_build, e_product, e_install_ids, combo_arch, chk_dry, UIng::Checkbox.new(""), include_install: false)
+    args << "--install-plugin" << ids.join(",")
+    new_run_header("Update selected plugins", args)
     run_cli(args)
     save_plugins_settings(e_plugins_dir, e_build, e_product, e_install_ids, combo_arch, combo_products, chk_dry)
   end

--- a/jb_updater/src/jb_updater/cli.cr
+++ b/jb_updater/src/jb_updater/cli.cr
@@ -118,7 +118,7 @@ module JBUpdater
       parser.on("--no-tty-progress-bar", "Disable ASCII progress bars on stdout for downloads") do
         opts.no_tty_progress_bar = true
       end
-      parser.on("--brew", "Patch Homebrew cask Ruby file instead of direct install") { opts.brew_patch = nil }
+      parser.on("--brew", "Patch Homebrew cask Ruby file instead of direct install") { opts.brew_patch = true }
       parser.on("-h", "--help", "Show help") do
         puts parser
         exit 0

--- a/jb_updater/src/jb_updater/clipboard.cr
+++ b/jb_updater/src/jb_updater/clipboard.cr
@@ -1,0 +1,48 @@
+module JBUpdater
+  # Minimal cross-platform clipboard helper used by the GUI.
+  #
+  # Delegates to the platform clipboard program:
+  # - **macOS**: `pbcopy`
+  # - **Linux**: `wl-copy`, then `xclip`, then `xsel`
+  # - **Windows**: `clip`
+  #
+  # Returns `false` when no suitable clipboard program is available.
+  module Clipboard
+    extend self
+
+    # Copies `text` to the system clipboard.
+    #
+    # @param text [String] Text to copy
+    # @return [Bool] `true` when copied successfully
+    def copy(text : String) : Bool
+      {% if flag?(:darwin) %}
+        run_copy("pbcopy", text)
+      {% elsif flag?(:win32) %}
+        run_copy("clip", text)
+      {% else %}
+        copy_linux(text)
+      {% end %}
+    end
+
+    private def copy_linux(text : String) : Bool
+      ["wl-copy", "xclip", "xsel"].each do |tool|
+        return true if run_copy(tool, text)
+      end
+      false
+    end
+
+    private def run_copy(tool : String, text : String) : Bool
+      command = tool
+      args = [] of String
+      if tool == "xclip"
+        args = ["-selection", "clipboard"]
+      elsif tool == "xsel"
+        args = ["--clipboard", "--input"]
+      end
+      Process.run(command, args: args, input: IO::Memory.new(text),
+        output: Process::Redirect::Close, error: Process::Redirect::Close).success?
+    rescue
+      false
+    end
+  end
+end

--- a/jb_updater/src/jb_updater/detect_products.cr
+++ b/jb_updater/src/jb_updater/detect_products.cr
@@ -75,7 +75,7 @@ module JBUpdater
           build = build_code(name, code, app)
 
           config_base = Utils.jetbrains_config_base
-          config_dir = Dir.glob(File.join(config_base, "#{name}*")).first?
+          config_dir = Utils.latest_versioned_config_dir(config_base, name)
           plugins_dir = config_dir ? File.join(config_dir, "plugins") : nil
 
           products << DetectedProduct.new(

--- a/jb_updater/src/jb_updater/gui_actions.cr
+++ b/jb_updater/src/jb_updater/gui_actions.cr
@@ -10,8 +10,9 @@ module JBUpdater
       # Resolves the IDE build string from user input or auto-detection.
       #
       # Priority:
-      # 1. `ide_product_text` (IDE tab's "IDE code or name" field)
-      # 2. `build_text` (Plugins tab's "Build" field)
+      # 1. `build_text` (Plugins tab's "Build" field) — the form the user is
+      #    actually looking at when installing/updating plugins
+      # 2. `ide_product_text` (IDE tab's "IDE code or name" field)
       # 3. First detected product's build from {DetectProducts.all}
       # 4. Fallback `"IC-252"`
       #
@@ -24,9 +25,9 @@ module JBUpdater
         build_text : String?,
         detected : Array(DetectedProduct),
       ) : String
-        code = ide_product_text
-        return code if code && !code.empty?
         code = build_text
+        return code if code && !code.empty?
+        code = ide_product_text
         return code if code && !code.empty?
         if d = detected.first?
           return d.build

--- a/jb_updater/src/jb_updater/ide_releases.cr
+++ b/jb_updater/src/jb_updater/ide_releases.cr
@@ -65,7 +65,9 @@ module JBUpdater
 
       body = res.body || raise "empty response body"
       data = JSON.parse(body)
-      arr = data[product_code]?.try &.as_a?
+
+      arr = extract_releases_arr(data, product_code)
+
       if arr.nil? || arr.empty?
         raise "IDEReleases: no releases found for product code '#{product_code}' " \
               "(check the --product value or configured product code)"
@@ -135,6 +137,24 @@ module JBUpdater
       end
     rescue
       "intel"
+    end
+
+    # Extracts the releases array from the JetBrains Releases API response.
+    #
+    # The API normally maps the requested product code to an array, but
+    # occasionally returns the array under a *variant* key (for example
+    # `"IIU"` for code `"IU"`). The exact code key wins; otherwise the
+    # first array-valued entry of the response is used.
+    #
+    # @param data [JSON::Any] Parsed API response object
+    # @param product_code [String] Requested product code (e.g. `"IU"`)
+    # @return [Array(JSON::Any)?] Releases array, or `nil` when absent
+    def extract_releases_arr(data : JSON::Any, product_code : String) : Array(JSON::Any)?
+      if exact = data[product_code]?
+        exact.as_a?
+      else
+        data.as_h.values.compact_map(&.as_a?).first?
+      end
     end
   end
 end

--- a/jb_updater/src/jb_updater/ide_releases.cr
+++ b/jb_updater/src/jb_updater/ide_releases.cr
@@ -66,7 +66,10 @@ module JBUpdater
       body = res.body || raise "empty response body"
       data = JSON.parse(body)
       arr = data[product_code]?.try &.as_a?
-      raise "IDEReleases: unexpected JSON for #{product_code}" if arr.nil? || arr.empty?
+      if arr.nil? || arr.empty?
+        raise "IDEReleases: no releases found for product code '#{product_code}' " \
+              "(check the --product value or configured product code)"
+      end
 
       releases = [] of IDERelease
 

--- a/jb_updater/src/jb_updater/ide_updater.cr
+++ b/jb_updater/src/jb_updater/ide_updater.cr
@@ -40,6 +40,13 @@ module JBUpdater
       build_url = latest_ide_download_url(product)
       final_uri = HTTPClient.override_ide_repo_host(build_url, opts.ide_downloads_host)
 
+      if opts.dry_run?
+        Log.header("Dry run — no files will be downloaded or modified")
+        Log.info("Would download: #{final_uri}")
+        Log.info("Mode: #{opts.brew_patch ? "Homebrew cask patch" : "direct DMG download"}")
+        return
+      end
+
       if opts.brew_patch
         patch_homebrew_cask(product, final_uri)
       else
@@ -66,8 +73,13 @@ module JBUpdater
 
       body = res.body || raise "empty response body"
       data = JSON.parse(body)
-      version = data[product_code][0]["version"].as_s
-      downloads = data[product_code][0]["downloads"]
+
+      releases = IDEReleases.extract_releases_arr(data, product_code)
+      release = releases.try(&.first?)
+      raise "No downloads found for product code '#{product_code}'" unless release
+
+      version = release["version"].as_s
+      downloads = release["downloads"]
 
       platform_key = download_key_for(platform, opts.arch)
 
@@ -161,6 +173,11 @@ module JBUpdater
             end
       dmg_path = File.join(Dir.tempdir, "upgrade-#{product}-#{Time.utc.to_unix}#{ext}")
 
+      if opts.dry_run?
+        Log.warn("Dry run: would download #{uri} to #{dmg_path}")
+        return
+      end
+
       cdn_uri = uri
 
       Log.header("Downloading #{product} from #{cdn_uri.host}…")
@@ -216,6 +233,13 @@ module JBUpdater
 
       content = File.read(cask_path)
       new_content = content.gsub(/url\s+["'].*["']/, %(url "#{uri}"))
+
+      if opts.dry_run?
+        Log.warn("Dry run: would patch #{cask_path}")
+        Log.info("Replacing cask url with: #{uri}")
+        return
+      end
+
       File.write(cask_path, new_content)
 
       Log.success("Patched cask: #{cask_path}")

--- a/jb_updater/src/jb_updater/plugin_marketplace.cr
+++ b/jb_updater/src/jb_updater/plugin_marketplace.cr
@@ -44,6 +44,13 @@ module JBUpdater
     getter vendor : String?
     # Preview image URL, or `nil`.
     getter preview : String?
+    # Warning note about compatibility with the selected IDE build, or `nil`.
+    #
+    # Set when a plugin is only found through an older-build fallback
+    # (e.g. DocScribe declares support only up to `261.*` but is shown
+    # for a `262` IDE). It may still work — author just hasn't widened
+    # the declared range — so it is a soft warning, not a hard block.
+    getter compat_note : String?
 
     # @param id [Int64] Marketplace numeric ID
     # @param xml_id [String] XML identifier
@@ -57,6 +64,7 @@ module JBUpdater
     # @param tags [Array(String)] Tag list
     # @param vendor [String?] Vendor name
     # @param preview [String?] Preview image URL
+    # @param compat_note [String?] Compatibility warning note
     def initialize(
       @id : Int64,
       @xml_id : String,
@@ -70,7 +78,22 @@ module JBUpdater
       @tags : Array(String) = [] of String,
       @vendor : String? = nil,
       @preview : String? = nil,
+      @compat_note : String? = nil,
     )
+    end
+
+    # Returns a copy of this plugin with a compatibility note attached.
+    #
+    # `PluginInfo` is a value struct; the note is only known after the
+    # plugin has been fetched (e.g. as an older-build fallback hit).
+    #
+    # @param note [String] Warning text (e.g. `"Declared only up to 261.*"`)
+    # @return [PluginInfo] Copy with `compat_note` set
+    def with_compat_note(note : String) : PluginInfo
+      PluginInfo.new(
+        id, xml_id, name, description, icon, categories, downloads, rating,
+        author, tags, vendor, preview, note
+      )
     end
 
     # Parses the JetBrains Marketplace XML response into an array of `PluginInfo`.
@@ -260,7 +283,8 @@ module JBUpdater
         # with the requested build. Some plugins declare a narrow range
         # (e.g. DocScribe: `261.*`) yet still work on newer IDEs. Fall
         # back through older builds of the same product so they show up
-        # in search results.
+        # in search results. Plugins found this way are flagged with a
+        # compatibility note (soft warning — they usually still work).
         if results.empty?
           Utils.previous_builds(build, limit: 4).each do |alt_build|
             alt = list_by_build(alt_build).select do |plugin|
@@ -268,7 +292,8 @@ module JBUpdater
                 plugin.xml_id.downcase.includes?(query_lower)
             end
             unless alt.empty?
-              results = alt
+              note = "Declared for build #{alt_build}, not for #{build} — may still work"
+              results = alt.map(&.with_compat_note(note))
               break
             end
           end

--- a/jb_updater/src/jb_updater/plugin_marketplace.cr
+++ b/jb_updater/src/jb_updater/plugin_marketplace.cr
@@ -86,53 +86,60 @@ module JBUpdater
       begin
         doc = XML.parse(cleaned)
         doc.xpath_nodes("//idea-plugin").each do |plugin_node|
-          next unless plugin_node
-
-          xml_id = ""
-          name = ""
-          description = ""
-          vendor = ""
-
-          if id_node = plugin_node.xpath_node("id")
-            xml_id = id_node.content
+          if plugin = parse_plugin_node(plugin_node)
+            result << plugin
           end
-          if name_node = plugin_node.xpath_node("name")
-            name = name_node.content
-          end
-          if desc_node = plugin_node.xpath_node("description")
-            description = desc_node.content
-          end
-          if vendor_node = plugin_node.xpath_node("vendor")
-            vendor = vendor_node.content
-          end
-
-          downloads = 0_i64
-          if dm = plugin_node["downloads"]?
-            downloads = dm.to_i64 rescue 0_i64
-          end
-
-          categories = [] of String
-          if tag_node = plugin_node.xpath_node("tags")
-            tag_node.content.split(",").each do |tag|
-              t = tag.strip
-              categories << t unless t.empty? || categories.includes?(t)
-            end
-          end
-
-          result << PluginInfo.new(
-            id: 0_i64,
-            xml_id: xml_id,
-            name: name,
-            description: JBUpdater.html_strip(description).gsub(/\s+/, " ").strip,
-            categories: categories,
-            downloads: downloads,
-            vendor: vendor,
-          )
         end
       rescue
       end
 
       result
+    end
+
+    # Extracts a single `PluginInfo` from an `<idea-plugin>` XML node.
+    #
+    # Missing optional fields (rating, downloads, tags) default safely.
+    #
+    # @param plugin_node [XML::Node] The `<idea-plugin>` element
+    # @return [PluginInfo?] Parsed plugin, or `nil` for empty nodes
+    private def self.parse_plugin_node(plugin_node : XML::Node) : PluginInfo?
+      xml_id = node_text(plugin_node, "id")
+      return if xml_id.empty?
+
+      description = node_text(plugin_node, "description")
+      downloads = 0_i64
+      if dm = plugin_node["downloads"]?
+        downloads = dm.to_i64 rescue 0_i64
+      end
+      rating = node_text(plugin_node, "rating").to_f rescue 0.0
+
+      categories = [] of String
+      if tag_node = plugin_node.xpath_node("tags")
+        tag_node.content.split(",").each do |tag|
+          t = tag.strip
+          categories << t unless t.empty? || categories.includes?(t)
+        end
+      end
+
+      PluginInfo.new(
+        id: 0_i64,
+        xml_id: xml_id,
+        name: node_text(plugin_node, "name"),
+        description: JBUpdater.html_strip(description).gsub(/\s+/, " ").strip,
+        categories: categories,
+        downloads: downloads,
+        rating: rating,
+        vendor: node_text(plugin_node, "vendor"),
+      )
+    end
+
+    # Reads the text content of a direct child element, or `""`.
+    #
+    # @param node [XML::Node] Parent element
+    # @param element [String] Child element name
+    # @return [String] Element content or empty string
+    private def self.node_text(node : XML::Node, element : String) : String
+      node.xpath_node(element).try(&.content) || ""
     end
 
     # Returns the direct file download URL for this plugin.
@@ -170,13 +177,15 @@ module JBUpdater
       end
     end
 
-    # Placeholder star rating display.
+    # Renders the plugin's average rating as filled/empty stars.
     #
-    # Currently always returns five stars.
+    # Returns an em-dash for unrated plugins.
     #
-    # @return [String] `"⭐⭐⭐⭐⭐"`
+    # @return [String] e.g. `"★★★★☆"` or `"—"`
     def star_rating : String
-      "⭐" * 5
+      return "—" if rating <= 0.0
+      filled = rating.round.to_i.clamp(0, 5)
+      "★" * filled + "☆" * (5 - filled)
     end
   end
 
@@ -187,10 +196,11 @@ module JBUpdater
   # build string to avoid redundant requests.
   class PluginMarketplace
     @@cache = {} of String => Array(PluginInfo)
+    @@cache_mutex = Mutex.new
 
     # Clears the in-memory plugin list cache.
     def self.clear_cache
-      @@cache.clear
+      @@cache_mutex.synchronize { @@cache.clear }
     end
 
     # Fetches (or returns cached) plugin list for a given IDE build.
@@ -201,7 +211,7 @@ module JBUpdater
     # @param build [String] IDE build string
     # @return [Array(PluginInfo)] List of available plugins
     def self.list_by_build(build : String) : Array(PluginInfo)
-      cached = @@cache[build]?
+      cached = @@cache_mutex.synchronize { @@cache[build]? }
       return cached if cached
 
       params = HTTP::Params{"build" => build}
@@ -209,7 +219,7 @@ module JBUpdater
       xml_str = fetch_raw_with_retry(url)
       return [] of PluginInfo if xml_str.nil? || xml_str.empty?
       plugins = PluginInfo.parse(xml_str)
-      @@cache[build] = plugins
+      @@cache_mutex.synchronize { @@cache[build] = plugins }
       plugins
     end
 

--- a/jb_updater/src/jb_updater/plugin_marketplace.cr
+++ b/jb_updater/src/jb_updater/plugin_marketplace.cr
@@ -251,10 +251,30 @@ module JBUpdater
         plugins
       else
         query_lower = query.downcase
-        plugins.select do |plugin|
+        results = plugins.select do |plugin|
           plugin.name.downcase.includes?(query_lower) ||
             plugin.xml_id.downcase.includes?(query_lower)
         end
+
+        # The plugin list API only returns plugins explicitly compatible
+        # with the requested build. Some plugins declare a narrow range
+        # (e.g. DocScribe: `261.*`) yet still work on newer IDEs. Fall
+        # back through older builds of the same product so they show up
+        # in search results.
+        if results.empty?
+          Utils.previous_builds(build, limit: 4).each do |alt_build|
+            alt = list_by_build(alt_build).select do |plugin|
+              plugin.name.downcase.includes?(query_lower) ||
+                plugin.xml_id.downcase.includes?(query_lower)
+            end
+            unless alt.empty?
+              results = alt
+              break
+            end
+          end
+        end
+
+        results
       end
     end
 

--- a/jb_updater/src/jb_updater/plugin_meta.cr
+++ b/jb_updater/src/jb_updater/plugin_meta.cr
@@ -1,4 +1,5 @@
 require "xml"
+require "compress/zip"
 require "./utils"
 
 module JBUpdater
@@ -111,13 +112,13 @@ module JBUpdater
       nil
     end
 
-    # Reads a file from inside a JAR using `unzip -p`.
+    # Reads a file from inside a JAR using a byte-level reader.
+    #
+    # Unlike `Compress::Zip`, this never parses DOS timestamps and never
+    # spawns a subprocess, so it is safe from background threads and
+    # immune to `Invalid time` failures on JetBrains archives.
     def self.read_text_from_jar(jar_path : String, inner_path : String) : String?
-      io = IO::Memory.new
-      status = Process.run("unzip", {"-p", jar_path, inner_path}, output: io, error: :close)
-      status.success? ? io.to_s : nil
-    rescue
-      nil
+      Utils.read_zip_file(jar_path, inner_path)
     end
   end
 end

--- a/jb_updater/src/jb_updater/updater.cr
+++ b/jb_updater/src/jb_updater/updater.cr
@@ -382,38 +382,42 @@ module JBUpdater
     # @param build [String] IDE build string
     # @return [URI] Resolved download URL
     private def resolve_download_url_via_plugin_manager(xml_id : String, build : String) : URI
-      base = "https://plugins.jetbrains.com/pluginManager?action=download&id=#{Utils.escape(xml_id)}&build=#{Utils.escape(build)}"
-      Log.info "Resolving download URL via pluginManager: #{base}"
-      res = HTTPClient.head_or_get(base)
-      case res.status_code
+      candidates = [build] + Utils.previous_builds(build, limit: 4)
+
+      candidates.each do |candidate|
+        base = "https://plugins.jetbrains.com/pluginManager?action=download&id=#{Utils.escape(xml_id)}&build=#{Utils.escape(candidate)}"
+        Log.info "Resolving download URL via pluginManager: #{base}"
+        res = HTTPClient.head_or_get(base)
+        case res.status_code
+        when 301, 302
+          loc = res.headers["Location"]?
+          raise "Missing Location header from pluginManager" unless loc
+          loc_uri = URI.parse(loc)
+          Log.info "pluginManager redirect for #{xml_id}: #{loc}"
+          return loc_uri.absolute? ? loc_uri : URI.parse("https://plugins.jetbrains.com#{loc}")
+        when 200
+          Log.info "pluginManager returned 200 for #{xml_id}, using direct URL"
+          return URI.parse(base)
+        else
+          Log.info "pluginManager #{res.status_code} for #{xml_id} build #{candidate}, trying next..."
+        end
+      end
+
+      Log.info "pluginManager failed for #{xml_id} on all builds, trying plugin/download fallback..."
+      fallback = "https://plugins.jetbrains.com/plugin/download?pluginId=#{Utils.escape(xml_id)}"
+      res2 = HTTPClient.head_or_get(fallback)
+      case res2.status_code
       when 301, 302
-        loc = res.headers["Location"]?
-        raise "Missing Location header from pluginManager" unless loc
+        loc = res2.headers["Location"]?
+        raise "Missing Location header from plugin/download" unless loc
         loc_uri = URI.parse(loc)
-        Log.info "pluginManager redirect for #{xml_id}: #{loc}"
+        Log.info "plugin/download redirect for #{xml_id}: #{loc}"
         loc_uri.absolute? ? loc_uri : URI.parse("https://plugins.jetbrains.com#{loc}")
       when 200
-        Log.info "pluginManager returned 200 for #{xml_id}, using direct URL"
-        URI.parse(base)
-      when 404
-        Log.info "pluginManager 404 for #{xml_id} (incompatible with #{build}), trying plugin/download fallback..."
-        fallback = "https://plugins.jetbrains.com/plugin/download?pluginId=#{Utils.escape(xml_id)}"
-        res2 = HTTPClient.head_or_get(fallback)
-        case res2.status_code
-        when 301, 302
-          loc = res2.headers["Location"]?
-          raise "Missing Location header from plugin/download" unless loc
-          loc_uri = URI.parse(loc)
-          Log.info "plugin/download redirect for #{xml_id}: #{loc}"
-          loc_uri.absolute? ? loc_uri : URI.parse("https://plugins.jetbrains.com#{loc}")
-        when 200
-          Log.info "plugin/download returned 200 for #{xml_id}, using direct URL"
-          URI.parse(fallback)
-        else
-          raise "plugin not found for #{xml_id} (pluginManager 404, plugin/download #{res2.status_code})"
-        end
+        Log.info "plugin/download returned 200 for #{xml_id}, using direct URL"
+        URI.parse(fallback)
       else
-        raise "pluginManager failed (HTTP #{res.status_code}) for #{xml_id} build #{build}"
+        raise "plugin not found for #{xml_id} (pluginManager 404 on all builds, plugin/download #{res2.status_code})"
       end
     end
   end

--- a/jb_updater/src/jb_updater/utils.cr
+++ b/jb_updater/src/jb_updater/utils.cr
@@ -135,25 +135,6 @@ module JBUpdater
       entries
     end
 
-    private def self.extract_zip_entries(zip_path : String, dest_dir : String) : Nil
-      entries = zip_file_entries(zip_path)
-
-      entries.each do |name, method, comp_size, offset|
-        target = File.join(dest_dir, name)
-        FileUtils.mkdir_p(File.dirname(target))
-        File.open(target, "w") do |out_file|
-          zip_entry_bytes(zip_path, method, comp_size, offset) do |io|
-            if method == 0
-              IO.copy(io, out_file, comp_size)
-            else
-              reader = Compress::Deflate::Reader.new(io)
-              IO.copy(reader, out_file)
-            end
-          end
-        end
-      end
-    end
-
     # Extracts a zip archive to a directory using a byte-level reader.
     private def self.extract_zip_entries(zip_path : String, dest_dir : String) : Nil
       entries = zip_file_entries(zip_path)

--- a/jb_updater/src/jb_updater/utils.cr
+++ b/jb_updater/src/jb_updater/utils.cr
@@ -123,21 +123,37 @@ module JBUpdater
     #
     # Strips trailing version numbers and spaces, matches the base
     # name case-insensitively, and returns the short code
-    # (e.g. `"RubyMine2025.2"` -> `"RM"`, `"phpstorm"` -> `"PS"`).
+    # (e.g. `"RubyMine2025.2"` -> `"RM"`, `"ruby"` -> `"RM"`).
     # Unknown names fall back to the first two uppercase characters.
     #
     # @param name [String] Product name (e.g. `"RubyMine2025.2"` or `"phpstorm"`)
     # @return [String] Product code (e.g. `"RM"`)
     def self.product_code(name : String) : String
       mapping = {
-        "rubymine" => "RM",
-        "webstorm" => "WS",
-        "pycharm"  => "PY",
-        "clion"    => "CL",
-        "goland"   => "GO",
-        "intellij" => "IU",
-        "phpstorm" => "PS",
-        "rider"    => "RD",
+        "ruby"      => "RM",
+        "rubymine"  => "RM",
+        "rm"        => "RM",
+        "webstorm"  => "WS",
+        "ws"        => "WS",
+        "pycharm"   => "PY",
+        "py"        => "PY",
+        "clion"     => "CL",
+        "cl"        => "CL",
+        "goland"    => "GO",
+        "go"        => "GO",
+        "intellij"  => "IU",
+        "idea"      => "IU",
+        "iu"        => "IU",
+        "phpstorm"  => "PS",
+        "ps"        => "PS",
+        "rider"     => "RD",
+        "rd"        => "RD",
+        "datagrip"  => "DG",
+        "dg"        => "DG",
+        "dataspell" => "DS",
+        "ds"        => "DS",
+        "aqua"      => "QA",
+        "appcode"   => "AC",
       }
 
       key = name.gsub(/[\d ].*/, "").downcase
@@ -197,10 +213,10 @@ module JBUpdater
       begin
         Dir.each_child(base_dir) do |entry|
           next unless pattern.matches?(entry)
+          next if backup_folder?(entry)
           tail = entry.sub(/^#{short}/i, "")
           next if tail.empty?
-          parts = tail.split('.', 3)
-          numbers = parts.map(&.to_f).fill(0.0, parts.size...3)
+          numbers = version_numbers(tail)
           matches << {entry, numbers}
         end
       rescue File::NotFoundError
@@ -210,6 +226,32 @@ module JBUpdater
       raise "No config folder found for product '#{short}' under #{base_dir}" if matches.empty?
 
       matches.max_by(&.[1])[0]
+    end
+
+    # Extracts up to three version numbers from a product folder suffix.
+    #
+    # Tolerates non-numeric fragments (e.g. `"2025.2-backup"` → `[2025.0, 2.0]`)
+    # instead of raising on `String#to_f`.
+    #
+    # @param tail [String] Folder name suffix after the product name
+    # @return [Array(Float64)] Three-element version array
+    def self.version_numbers(tail : String) : Array(Float64)
+      parts = tail.split('.', 3)
+      numbers = parts.map do |part|
+        match = part.match(/\A[^0-9]*(\d+(?:\.\d+)?)/)
+        match ? match[1].to_f : 0.0
+      end
+      numbers.push(0.0, 0.0, 0.0)[0, 3]
+    end
+
+    # Detects backup-style folder names produced by updater backups.
+    #
+    # Matches `.bak`, `.bak.<timestamp>`, `-backup`, and `_backup` suffixes.
+    #
+    # @param entry [String] Folder name
+    # @return [Bool] `true` if the name looks like a backup folder
+    def self.backup_folder?(entry : String) : Bool
+      entry.matches?(/(\.bak|[-_]?backup)/i)
     end
 
     # Returns the `plugins` subdirectory for a JetBrains product, creating it if needed.

--- a/jb_updater/src/jb_updater/utils.cr
+++ b/jb_updater/src/jb_updater/utils.cr
@@ -1,4 +1,6 @@
 require "file_utils"
+require "compress/zip"
+require "compress/deflate"
 
 module JBUpdater
   # Shared utility methods used across the codebase.
@@ -35,18 +37,11 @@ module JBUpdater
       str.gsub(/[^A-Za-z0-9_.-]/, "_")
     end
 
-    # Checks whether the `unzip` tool is available on `$PATH`.
+    # Extracts a ZIP archive into a target directory using the pure-Crystal
+    # `Compress::Zip` stdlib reader (no external `unzip` binary).
     #
-    # @return [Bool] `true` if `which unzip` succeeds
-    def self.unzip_available? : Bool
-      status = Process.run("which",
-        args: ["unzip"],
-        output: Process::Redirect::Close,
-        error: Process::Redirect::Close)
-      status.success?
-    end
-
-    # Extracts a ZIP archive into a target directory.
+    # Runs safely from background threads — unlike `Process.run` which
+    # deadlocks in spawned threads on some Crystal versions.
     #
     # If the archive contains a single root directory its contents are
     # flattened into `dest_dir`. Existing directories are backed up
@@ -54,16 +49,14 @@ module JBUpdater
     #
     # @param zip_path [String] Path to the ZIP file
     # @param dest_dir [String] Target installation directory
-    # @raise [RuntimeError] If `unzip` is not found or the command fails
+    # @raise [RuntimeError] If the archive cannot be read or extracted
     def self.extract_zip(zip_path : String, dest_dir : String) : Nil
-      raise "'unzip' not found" unless unzip_available?
       tmp_root = File.join(Dir.tempdir,
         "jb-plg-#{Time.utc.to_unix}-#{Random::Secure.hex(4)}")
       FileUtils.mkdir_p(tmp_root)
 
       begin
-        status = Process.run("unzip", args: ["-qq", "-o", zip_path, "-d", tmp_root])
-        raise "unzip failed for #{zip_path}" unless status.success?
+        extract_zip_entries(zip_path, tmp_root)
 
         entries = Dir.children(tmp_root).reject(&.==("__MACOSX"))
         root = if entries.size == 1 && File.directory?(File.join(tmp_root, entries.first))
@@ -83,6 +76,151 @@ module JBUpdater
       ensure
         FileUtils.rm_rf(tmp_root)
       end
+    end
+
+    # Parses the central directory of a zip and returns file entries
+    # (name, method, compressed size, local header offset).
+    #
+    # Unlike `Compress::Zip`, this never touches DOS timestamps, so
+    # archives with invalid timestamp fields (common on JetBrains
+    # marketplace) are still readable.
+    private def self.zip_file_entries(zip_path : String) : Array(Tuple(String, UInt16, UInt32, UInt32))
+      file_bytes = File.open(zip_path, "rb") { |file| file.gets_to_end.to_slice }
+      io = IO::Memory.new(file_bytes)
+      le = IO::ByteFormat::LittleEndian
+
+      eocd = -1
+      search_from = [file_bytes.size - 65_557, 0].max
+      i = file_bytes.size - 4
+      while i >= search_from
+        if file_bytes[i] == 0x50 && file_bytes[i + 1] == 0x4B &&
+           file_bytes[i + 2] == 0x05 && file_bytes[i + 3] == 0x06
+          eocd = i
+          break
+        end
+        i -= 1
+      end
+      raise "Invalid zip: end of central directory not found" if eocd < 0
+
+      io.pos = eocd + 10
+      total = io.read_bytes(UInt16, le)
+      io.pos = eocd + 16
+      cd_offset = io.read_bytes(UInt32, le)
+      raise "Invalid zip: bad central directory offset" if cd_offset >= file_bytes.size
+
+      entries = Array(Tuple(String, UInt16, UInt32, UInt32)).new(total)
+
+      io.pos = cd_offset.to_i
+      total.times do
+        sig = io.read_bytes(UInt32, le)
+        raise "Invalid zip: bad central directory entry" unless sig == 0x02014B50
+        io.pos += 2 + 2 + 2 # version made / needed / flags
+        method = io.read_bytes(UInt16, le)
+        io.pos += 2 + 2 + 4 # mod time / date / crc
+        comp_size = io.read_bytes(UInt32, le)
+        io.pos += 4 # uncomp size
+        name_len = io.read_bytes(UInt16, le)
+        extra_len = io.read_bytes(UInt16, le)
+        comment_len = io.read_bytes(UInt16, le)
+        io.pos += 2 + 2 + 4 # disk start / internal / external attrs
+        offset = io.read_bytes(UInt32, le)
+        name_bytes = Bytes.new(name_len)
+        io.read_fully(name_bytes)
+        io.pos += extra_len + comment_len
+        name = String.new(name_bytes)
+        next if name.ends_with?('/') || name.starts_with?("__MACOSX/") || name.includes?("..")
+        entries << {name, method, comp_size, offset}
+      end
+
+      entries
+    end
+
+    private def self.extract_zip_entries(zip_path : String, dest_dir : String) : Nil
+      entries = zip_file_entries(zip_path)
+
+      entries.each do |name, method, comp_size, offset|
+        target = File.join(dest_dir, name)
+        FileUtils.mkdir_p(File.dirname(target))
+        File.open(target, "w") do |out_file|
+          zip_entry_bytes(zip_path, method, comp_size, offset) do |io|
+            if method == 0
+              IO.copy(io, out_file, comp_size)
+            else
+              reader = Compress::Deflate::Reader.new(io)
+              IO.copy(reader, out_file)
+            end
+          end
+        end
+      end
+    end
+
+    # Extracts a zip archive to a directory using a byte-level reader.
+    private def self.extract_zip_entries(zip_path : String, dest_dir : String) : Nil
+      entries = zip_file_entries(zip_path)
+
+      entries.each do |name, method, comp_size, offset|
+        target = File.join(dest_dir, name)
+        FileUtils.mkdir_p(File.dirname(target))
+        File.open(target, "w") do |out_file|
+          zip_entry_bytes(zip_path, method, comp_size, offset) do |io|
+            if method == 0
+              IO.copy(io, out_file, comp_size)
+            else
+              reader = Compress::Deflate::Reader.new(io)
+              IO.copy(reader, out_file)
+            end
+          end
+        end
+      end
+    end
+
+    # Yields a deflate/stored entry's decompressed bytes stream.
+    private def self.zip_entry_bytes(zip_path : String, method : UInt16, comp_size : UInt32, offset : UInt32, & : IO ->)
+      file_bytes = File.open(zip_path, "rb") { |file| file.gets_to_end.to_slice }
+      io = IO::Memory.new(file_bytes)
+      le = IO::ByteFormat::LittleEndian
+
+      io.pos = offset.to_i
+      sig = io.read_bytes(UInt32, le)
+      raise "Invalid zip: bad local header" unless sig == 0x04034B50
+      io.pos += 2 + 2 + 2 + 2 + 2 + 4 + 4 + 4 # version/flag/method/time/date/crc/sizes
+      name_len = io.read_bytes(UInt16, le)
+      extra_len = io.read_bytes(UInt16, le)
+      io.pos += name_len + extra_len
+
+      if method == 0
+        yield io
+      elsif method == 8
+        comp_data = Bytes.new(comp_size)
+        io.read_fully(comp_data)
+        yield IO::Memory.new(comp_data)
+      else
+        raise "Invalid zip: unsupported compression method #{method}"
+      end
+    end
+
+    # Reads a single file out of a zip archive as a String.
+    #
+    # Returns `nil` if the entry is missing or cannot be decoded. Safe to
+    # call from background threads (no `Process.run`, no `Compress::Zip`
+    # timestamp bug).
+    def self.read_zip_file(zip_path : String, inner_path : String) : String?
+      entry = zip_file_entries(zip_path).find { |(name, _, _, _)| name == inner_path }
+      return nil unless entry
+      name, method, comp_size, offset = entry
+      result = String.build do |str|
+        zip_entry_bytes(zip_path, method, comp_size, offset) do |io|
+          if method == 0
+            IO.copy(io, str, comp_size)
+          else
+            reader = Compress::Deflate::Reader.new(io)
+            IO.copy(reader, str)
+          end
+        end
+      end
+      result
+    rescue
+      nil
     end
 
     # --------------------------------------------------------------------------

--- a/jb_updater/src/jb_updater/utils.cr
+++ b/jb_updater/src/jb_updater/utils.cr
@@ -223,6 +223,40 @@ module JBUpdater
       parts.fill(0.0, parts.size...3)
     end
 
+    # Generates older build identifiers for the same product code.
+    #
+    # Marketplace APIs filter plugins by strict build compatibility
+    # (e.g. DocScribe declares only `261.*`, skipping RubyMine 2026.2).
+    # This helper walks backwards in yearly/monor increments so callers
+    # can search/download across slightly older compatible builds.
+    #
+    # Example: `"RM-262"` → `["RM-261", "RM-253", "RM-252", "RM-251", ...]`
+    #
+    # @param build_str [String] Current build (e.g. `"RM-262.9437.192"`)
+    # @param limit [Int32] Maximum number of older builds to produce
+    # @return [Array(String)] Older build strings for the same product
+    def self.previous_builds(build_str : String, limit : Int32 = 8) : Array(String)
+      m = build_str.match(/^([A-Z]+)-(\d{3})/)
+      return [] of String unless m
+      code = m[1]
+      year = m[2][0, 2].to_i
+      minor = m[2][2].to_i
+      return [] of String if minor.zero?
+
+      result = [] of String
+      result << "#{code}-#{year}#{minor - 1}" if minor > 1
+
+      (year - 1).downto(year - 4) do |y|
+        break if result.size >= limit
+        [3, 2, 1].each do |alt_minor|
+          result << "#{code}-#{y}#{alt_minor}"
+          break if result.size >= limit
+        end
+      end
+
+      result[0...limit]
+    end
+
     # Checks whether a build version falls within a `[since, until]` range.
     #
     # A `nil` bound is treated as unbounded (0 for lower, infinity for upper).

--- a/jb_updater/src/jb_updater/utils.cr
+++ b/jb_updater/src/jb_updater/utils.cr
@@ -347,6 +347,38 @@ module JBUpdater
       matches.max_by(&.[1])[0]
     end
 
+    # Returns the newest versioned config directory for a product name.
+    #
+    # Unlike {resolve_product_folder} this is non-destructive (never creates
+    # the base dir) and returns an absolute path of a *matching* folder, or
+    # `nil` when no versioned folder exists. Backup folders are skipped.
+    #
+    # This is used by {DetectProducts.all} so a product with multiple config
+    # versions (e.g. `RubyMine2025.3`, `RubyMine2026.1`, `RubyMine2026.2`)
+    # resolves to the **latest** one instead of an arbitrary glob match.
+    #
+    # @param base_dir [String] JetBrains config base directory
+    # @param name [String] Product name (e.g. `"RubyMine"`)
+    # @return [String?] Absolute path of the newest matching dir, or `nil`
+    def self.latest_versioned_config_dir(base_dir : String, name : String) : String?
+      return nil unless Dir.exists?(base_dir)
+
+      pattern = /^#{Regex.escape(name)}(\d|$)/i
+      matches = [] of {String, Array(Float64)}
+
+      Dir.each_child(base_dir) do |entry|
+        next unless pattern.matches?(entry)
+        next if backup_folder?(entry)
+        tail = entry.sub(/^#{name}/i, "")
+        matches << {entry, tail.empty? ? [0.0, 0.0, 0.0] : version_numbers(tail)}
+      end
+
+      return nil if matches.empty?
+
+      best = matches.max_by(&.[1])[0]
+      File.join(base_dir, best)
+    end
+
     # Extracts up to three version numbers from a product folder suffix.
     #
     # Tolerates non-numeric fragments (e.g. `"2025.2-backup"` → `[2025.0, 2.0]`)

--- a/jb_updater/src/jb_updater/utils.cr
+++ b/jb_updater/src/jb_updater/utils.cr
@@ -85,7 +85,7 @@ module JBUpdater
     # archives with invalid timestamp fields (common on JetBrains
     # marketplace) are still readable.
     private def self.zip_file_entries(zip_path : String) : Array(Tuple(String, UInt16, UInt32, UInt32))
-      file_bytes = File.open(zip_path, "rb") { |file| file.gets_to_end.to_slice }
+      file_bytes = File.open(zip_path, "rb", &.gets_to_end.to_slice)
       io = IO::Memory.new(file_bytes)
       le = IO::ByteFormat::LittleEndian
 
@@ -157,7 +157,7 @@ module JBUpdater
 
     # Yields a deflate/stored entry's decompressed bytes stream.
     private def self.zip_entry_bytes(zip_path : String, method : UInt16, comp_size : UInt32, offset : UInt32, & : IO ->)
-      file_bytes = File.open(zip_path, "rb") { |file| file.gets_to_end.to_slice }
+      file_bytes = File.open(zip_path, "rb", &.gets_to_end.to_slice)
       io = IO::Memory.new(file_bytes)
       le = IO::ByteFormat::LittleEndian
 
@@ -187,8 +187,8 @@ module JBUpdater
     # timestamp bug).
     def self.read_zip_file(zip_path : String, inner_path : String) : String?
       entry = zip_file_entries(zip_path).find { |(name, _, _, _)| name == inner_path }
-      return nil unless entry
-      name, method, comp_size, offset = entry
+      return unless entry
+      _, method, comp_size, offset = entry
       result = String.build do |str|
         zip_entry_bytes(zip_path, method, comp_size, offset) do |io|
           if method == 0
@@ -361,7 +361,7 @@ module JBUpdater
     # @param name [String] Product name (e.g. `"RubyMine"`)
     # @return [String?] Absolute path of the newest matching dir, or `nil`
     def self.latest_versioned_config_dir(base_dir : String, name : String) : String?
-      return nil unless Dir.exists?(base_dir)
+      return unless Dir.exists?(base_dir)
 
       pattern = /^#{Regex.escape(name)}(\d|$)/i
       matches = [] of {String, Array(Float64)}
@@ -373,7 +373,7 @@ module JBUpdater
         matches << {entry, tail.empty? ? [0.0, 0.0, 0.0] : version_numbers(tail)}
       end
 
-      return nil if matches.empty?
+      return if matches.empty?
 
       best = matches.max_by(&.[1])[0]
       File.join(base_dir, best)


### PR DESCRIPTION
## Summary

Set of post-QA fixes for the `jb_updater` GUI and CLI, plus two usability additions:

- **Unsupported plugins are now searchable.** The Marketplace list API only returns plugins declared compatible with the current build, so plugins pinned to an older build (e.g. DocScribe `261.*` on a `262` IDE [https://github.com/FlorexLabs/docscribe-rubymine, https://github.com/unurgunite/docscribe]) were completely invisible. Search now falls back through older builds of the same product and flags such hits with a soft `⚠` warning — in the Browse table, in the detail pane, and on install — instead of hiding them.
- **GUI background threads now work reliably.** The GUI runs marketplace fetches, search, downloads, and IDE-release queries on background threads; on Crystal >= 1.21 the single-threaded runtime does not set up fiber execution contexts on `Thread.new` threads, which hung them. The GUI is built with `-Dpreview_mt` (documented in README).
- **Pure-Crystal ZIP reader.** Plugin archives are now extracted with a byte-level `Compress::Zip` reader instead of the system `unzip` binary, and it tolerates invalid DOS timestamps common in JetBrains marketplace archives.

## Changes

- `plugin_marketplace.cr`: older-build fallback search via `Utils.previous_builds`; `PluginInfo#compat_note` + `with_compat_note`; safer XML node parsing
- `main_gui.cr`: `⚠` compatibility marker in Browse table, detail pane, and install-status warning; toolbars reorganised (install-by-IDs removed; update actions moved to the Installed tab)
- `utils.cr`: `previous_builds`, `latest_versioned_config_dir`, pure-Crystal ZIP read/extract (`read_zip_file`)
- `detect_products.cr`: pick the newest matching config directory (`RubyMine2026.2` over `RubyMineEAP`, skips backups) using `latest_versioned_config_dir`
- `ide_releases.cr`: release list extraction and IDE release sorting fixes
- `README.md`: GUI build instructions (`-Dpreview_mt`) and background-threads note
- `.gitignore` update; Ameba cleanup; IDE-sorting and tables-layout fixes

## Verification

- [x] `crystal spec` passes — 129 examples, 0 failures
- [x] `bin/ameba` — 0 offenses